### PR TITLE
bugfix: rootsim-cc only works in debug mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -12,13 +12,20 @@ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 
 # Debugging symbols or not?
-CFLAGS="-O3 -lm -U_FORTIFY_SOURCE"
 AC_ARG_ENABLE([debug],
     AS_HELP_STRING([--enable-debug], [Enable debugging of the platform]))
 
-AS_IF([test "x$enable_debug" = "xyes"], [
-	CFLAGS="-g3 -Wall -Wextra -O0 -Wswitch-enum -Wcast-align -Wpointer-arith -Wstrict-overflow=5 -Wstrict-prototypes -Winline -Wundef -Wnested-externs -Wshadow -Wunreachable-code -Wfloat-equal -Wredundant-decls -Wold-style-definition -std=c99 -fno-omit-frame-pointer -ffloat-store -fno-common -fstrict-aliasing -fgnu89-inline -rdynamic -lm"
-])
+AM_CONDITIONAL([DEBUG], [test x$enable_debug = xyes])
+
+
+# Setup compilation flags
+CFLAGS_COMMON="-std=c99 -fno-omit-frame-pointer -ffloat-store -fno-common -fstrict-aliasing -fgnu89-inline -rdynamic -lm -U_FORTIFY_SOURCE"
+CFLAGS_WARNINGS="-Wall -Wextra -Wswitch-enum -Wcast-align -Wpointer-arith -Wstrict-overflow=5 -Wstrict-prototypes -Winline -Wundef -Wnested-externs -Wshadow -Wunreachable-code -Wfloat-equal -Wredundant-decls -Wold-style-definition"
+
+AM_COND_IF([DEBUG],
+		   [CFLAGS="-g3 -O0 $CFLAGS_COMMON $CFLAGS_WARNINGS"],
+		   [CFLAGS="-O3 $CFLAGS_COMMON"])
+
 
 AC_ARG_ENABLE([profile],
     AS_HELP_STRING([--enable-profile], [Enable profiling the platform]))


### PR DESCRIPTION
### Bug
Some flags were missing in the CFLAGS variable when the
debug mode was not active.
Since some of these flags are required, the compiled `rootsim-cc`
wasn't working when the debug mode is disabled.

### Fix
All the required compilation flags are stored in `CFLAGS_COMMON` and
are used both when debug mode is active as well when it is disabled.

### Bonus
The conditional variable DEBUG is now setup, it reflects the `--enable-debug` cli flag and can be used also in
the Makefile