### PR TITLE
bugfix: rootsim-cc does not clean temp files

### DIFF
--- a/scripts/rootsim-cc.in
+++ b/scripts/rootsim-cc.in
@@ -72,8 +72,8 @@ build_cleanup()
 #rm $$.ld-data1
 #rm $$.ld-data2
 #rm $$.ld-final
-rm *.o
-rm *.o.rs
+rm ${SOURCES//.c/.o}
+rm ${SOURCES//.c/.o.rs}
 #rm branch-table
 #rm branch-table-light
 #rm offset-table-start-inc


### PR DESCRIPTION
### Bug
In the cleanup phase it was wrongly assumed that the model sources
reside in the current working direcotry. Moreover temporary
files not produced in current session were deleted.

### Fix
The temporary files are correctly detected using the `SOURCES` file array.
Only the temporary files produced in the current session will be deleted