### PR TITLE
bugfix: indexing LPS data structure with LP global ID

### DIFF
--- a/src/communication/communication.c
+++ b/src/communication/communication.c
@@ -366,7 +366,7 @@ void send_outgoing_msgs(unsigned int lid) {
 		msg_hdr.timestamp = msg->timestamp;
 		msg_hdr.send_time = msg->send_time;
 		msg_hdr.mark = msg->mark;
-		(void)list_insert(msg->sender, LPS[msg->sender]->queue_out, send_time, &msg_hdr);
+		(void)list_insert(msg->sender, LPS[GidToLid(msg->sender)]->queue_out, send_time, &msg_hdr);
 	}
 
 	LPS[lid]->outgoing_buffer.size = 0;

--- a/src/queues/queues.c
+++ b/src/queues/queues.c
@@ -183,7 +183,7 @@ void process_bottom_halves(void) {
 
 		while((msg_to_process = (msg_t *)get_BH(LPS_bound[i]->lid)) != NULL) {
 
-			lid_receiver = msg_to_process->receiver;
+			lid_receiver = GidToLid(msg_to_process->receiver);
 
 			// TODO: reintegrare per ECS
 			//~ if(!receive_control_msg(msg_to_process)) {

--- a/src/scheduler/scheduler.c
+++ b/src/scheduler/scheduler.c
@@ -321,7 +321,7 @@ void initialize_worker_thread(void) {
 			type: INIT,
 			timestamp: 0.0,
 			send_time: 0.0,
-			mark: generate_mark(LidToGid(LPS_bound[t]->lid)),
+			mark: generate_mark(LPS_bound[t]->lid),
 			size: model_parameters.size,
 			message_kind: positive,
 		};


### PR DESCRIPTION
Every kernel has its own LPS data structure that must be indexed
with LP local ID (`lid`)