### PR TITLE
bufferoverflow bugfix

### DIFF
--- a/src/queues/queues.c
+++ b/src/queues/queues.c
@@ -195,7 +195,7 @@ void process_bottom_halves(void) {
 				// It's an antimessage
 				case negative:
 
-					statistics_post_lp_data(msg_to_process->receiver, STAT_ANTIMESSAGE, 1.0);
+					statistics_post_lp_data(lid_receiver, STAT_ANTIMESSAGE, 1.0);
 
 					// Find the message matching the antimessage
 					matched_msg = list_tail(LPS[lid_receiver]->queue_in);

--- a/src/queues/queues.c
+++ b/src/queues/queues.c
@@ -229,7 +229,8 @@ void process_bottom_halves(void) {
 						// If the matched message is in the past, we have to rollback
 						if(matched_msg->timestamp <= lvt(lid_receiver)) {
 							LPS[lid_receiver]->bound = list_prev(matched_msg);
-							while ((LPS[lid_receiver]->bound != NULL) && LPS[lid_receiver]->bound->timestamp == msg_to_process->timestamp) {
+							while ((LPS[lid_receiver]->bound != NULL) &&
+							       D_EQUAL(LPS[lid_receiver]->bound->timestamp, msg_to_process->timestamp)){
 								LPS[lid_receiver]->bound = list_prev(LPS[lid_receiver]->bound);
 							}
 							LPS[lid_receiver]->state = LP_STATE_ROLLBACK;
@@ -251,7 +252,8 @@ void process_bottom_halves(void) {
 					// Check if we've just inserted an out-of-order event
 					if(msg_to_process->timestamp < lvt(lid_receiver)) {
 						LPS[lid_receiver]->bound = list_prev(msg_to_process);
-						while ((LPS[lid_receiver]->bound != NULL) && LPS[lid_receiver]->bound->timestamp == msg_to_process->timestamp) {
+						while ((LPS[lid_receiver]->bound != NULL) &&
+						       D_EQUAL(LPS[lid_receiver]->bound->timestamp, msg_to_process->timestamp)){
 							LPS[lid_receiver]->bound = list_prev(LPS[lid_receiver]->bound);
 						}
 						LPS[lid_receiver]->state = LP_STATE_ROLLBACK;


### PR DESCRIPTION
the `statistics_post_lp_data` expect a lid as first parameter
but a gid was used instead. This led to a bufferoverflow.

The first commit is a minor bugfix