### PR TITLE
Distinguish between local and globa thread ID

### DIFF
--- a/src/arch/thread.c
+++ b/src/arch/thread.c
@@ -33,6 +33,7 @@
 static tid_t os_tid;
 
 __thread unsigned int tid;
+__thread unsigned int local_tid;
 
 static unsigned int thread_counter = 0;
 
@@ -57,18 +58,18 @@ static void *__helper_create_thread(void *arg) {
 
 	// Get a unique local thread id...
 	unsigned int old_counter;
-	unsigned int local_tid;
+	unsigned int _local_tid;
 
 	while(true) {
 		old_counter = thread_counter;
-		local_tid = old_counter + 1;
-		if(iCAS(&thread_counter, old_counter, local_tid)) {
+		_local_tid = old_counter + 1;
+		if(iCAS(&thread_counter, old_counter, _local_tid)) {
 			break;
 		}
 	}
-
+	local_tid = _local_tid;
 	// ...and make it globally unique
-	tid = (kid << (sizeof(unsigned int) * 8 / 2)) | local_tid;
+	tid = to_global_tid(kid, _local_tid);
 
 
 	// Set the affinity on a CPU core, for increased performance

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -158,6 +158,10 @@ static int parse_cmd_line(int argc, char **argv) {
 					rootsim_error(true, "Demanding a non-positive number of cores\n");
 					return -1;
 				}
+
+				if(n_cores > MAX_THREADS_PER_KERNEL){
+					rootsim_error(true, "Too many threads, maximum supported number is %u\n", MAX_THREADS_PER_KERNEL);
+				}
 				break;
 
 			case OPT_OUTPUT_DIR:

--- a/src/gvt/gvt.c
+++ b/src/gvt/gvt.c
@@ -218,14 +218,14 @@ simtime_t gvt_operations(void) {
 
 			for(i = 0; i < n_prc_per_thread; i++) {
 				if(LPS_bound[i]->bound == NULL) {
-					local_min[tid] = 0.0;
-					local_min_barrier[tid] = 0.0;
+					local_min[local_tid] = 0.0;
+					local_min_barrier[local_tid] = 0.0;
 					break;
 				}
 
-				local_min[tid] = min(local_min[tid], LPS_bound[i]->bound->timestamp);
+				local_min[local_tid] = min(local_min[local_tid], LPS_bound[i]->bound->timestamp);
 				tentative_barrier = find_time_barrier(LPS_bound[i]->lid, LPS_bound[i]->bound->timestamp);
-				local_min_barrier[tid] = min(local_min_barrier[tid], tentative_barrier->lvt);
+				local_min_barrier[local_tid] = min(local_min_barrier[local_tid], tentative_barrier->lvt);
 			}
 			my_phase = phase_send;	// Entering phase send
 			atomic_dec(&counter_A);	// Notify finalization of phase A
@@ -246,14 +246,14 @@ simtime_t gvt_operations(void) {
 
 			for(i = 0; i < n_prc_per_thread; i++) {
 				if(LPS_bound[i]->bound == NULL) {
-					local_min[tid] = 0.0;
-					local_min_barrier[tid] = 0.0;
+					local_min[local_tid] = 0.0;
+					local_min_barrier[local_tid] = 0.0;
 					break;
 				}
 
-				local_min[tid] = min(local_min[tid], LPS_bound[i]->bound->timestamp);
+				local_min[local_tid] = min(local_min[local_tid], LPS_bound[i]->bound->timestamp);
 				tentative_barrier = find_time_barrier(LPS_bound[i]->lid, LPS_bound[i]->bound->timestamp);
-				local_min_barrier[tid] = min(local_min_barrier[tid], tentative_barrier->lvt);
+				local_min_barrier[local_tid] = min(local_min_barrier[local_tid], tentative_barrier->lvt);
 			}
 
 			my_phase = phase_aware;
@@ -305,8 +305,8 @@ simtime_t gvt_operations(void) {
 
 			// Back to phase A for next GVT round
 			my_phase = phase_A;
-			local_min[tid] = INFTY;
-			local_min_barrier[tid] = INFTY;
+			local_min[local_tid] = INFTY;
+			local_min_barrier[local_tid] = INFTY;
 			atomic_dec(&counter_end);
 			last_gvt = adopted_last_gvt;
 		}

--- a/src/queues/queues.c
+++ b/src/queues/queues.c
@@ -286,7 +286,7 @@ void process_bottom_halves(void) {
 	// preemptive scheme will not detect this, and some events could
 	// be in fact executed out of error.
 	#ifdef HAVE_PREEMPTION
-	reset_min_in_transit(tid);
+	reset_min_in_transit(local_tid);
 	#endif
 }
 

--- a/src/scheduler/binding.c
+++ b/src/scheduler/binding.c
@@ -97,9 +97,9 @@ static inline void LPs_block_binding(void) {
 	while (i < n_prc) {
 		j = 0;
 		while (j < buf1) {
-			if(offset == tid) {
+			if(offset == local_tid) {
 				LPS_bound[n_prc_per_thread++] = LPS[i];
-				LPS[i]->worker_thread = tid;
+				LPS[i]->worker_thread = local_tid;
 			}
 			i++;
 			j++;
@@ -227,16 +227,16 @@ static void install_binding(void) {
 	n_prc_per_thread = 0;
 
 	for(i = 0; i < n_prc; i++) {
-		if(new_LPS_binding[i] == tid) {
+		if(new_LPS_binding[i] == local_tid) {
 			LPS_bound[n_prc_per_thread++] = LPS[i];
 
-			if(tid != LPS[i]->worker_thread) {
+			if(local_tid != LPS[i]->worker_thread) {
 
 				#ifdef HAVE_NUMA
 				move_request(i, get_numa_node(running_core()));
 				#endif
 
-				LPS[i]->worker_thread = tid;
+				LPS[i]->worker_thread = local_tid;
 			}
 		}
 	}
@@ -299,7 +299,7 @@ void rebind_LPs(void) {
 		install_binding();
 
 		#ifdef HAVE_PREEMPTION
-		reset_min_in_transit(tid);
+		reset_min_in_transit(local_tid);
 		#endif
 
 		if(thread_barrier(&all_thread_barrier)) {

--- a/src/scheduler/preempt.c
+++ b/src/scheduler/preempt.c
@@ -154,7 +154,7 @@ void preempt(void) {
 	if(platform_mode || rolling_back) {
 //		atomic_inc(&overtick_platform);
 
-	} else if(min_in_transit_lvt[tid] < current_lvt) {
+	} else if(min_in_transit_lvt[local_tid] < current_lvt) {
 //		atomic_inc(&would_preempt);
 		LPS[current_lp]->state = LP_STATE_SUSPENDED; // Questo triggera la logica di ripartenza dell'LP di ECS, ma forse va cambiato nome...
 		switch_to_platform_mode();
@@ -162,7 +162,7 @@ void preempt(void) {
 	}
 	
 
-/*	if(!platform_mode && min_in_transit_lvt[tid] < current_lvt) {
+/*	if(!platform_mode && min_in_transit_lvt[local_tid] < current_lvt) {
 
 		atomic_inc(&preempt_count);
 

--- a/src/statistics/statistics.c
+++ b/src/statistics/statistics.c
@@ -102,7 +102,7 @@ static inline FILE *get_file(unsigned int type, unsigned idx) {
 			FILE *f;
 
 			if(type == STAT_PER_THREAD)
-				f = thread_files[tid][idx];
+				f = thread_files[local_tid][idx];
 			else if(type == STAT_UNIQUE)
 				f = unique_files[idx];
 			return f;
@@ -376,27 +376,27 @@ void statistics_stop(int exit_code) {
 		for(i = 0; i < n_prc_per_thread; i++) {
 			unsigned int lid = LPS_bound[i]->lid;
 
-			thread_stats[tid].tot_antimessages += lp_stats[lid].tot_antimessages;
-			thread_stats[tid].tot_events += lp_stats[lid].tot_events;
-			thread_stats[tid].committed_events += lp_stats[lid].committed_events;
-			thread_stats[tid].reprocessed_events += lp_stats[lid].reprocessed_events;
-			thread_stats[tid].tot_rollbacks += lp_stats[lid].tot_rollbacks;
-			thread_stats[tid].tot_ckpts += lp_stats[lid].tot_ckpts;
-			thread_stats[tid].ckpt_time += lp_stats[lid].ckpt_time;
-			thread_stats[tid].ckpt_mem += lp_stats[lid].ckpt_mem;
-			thread_stats[tid].tot_recoveries += lp_stats[lid].tot_recoveries;
-			thread_stats[tid].recovery_time += lp_stats[lid].recovery_time;
-			thread_stats[tid].event_time += lp_stats[lid].event_time;
-			thread_stats[tid].exponential_event_time += lp_stats[lid].exponential_event_time;
-			thread_stats[tid].idle_cycles += lp_stats[lid].idle_cycles;
+			thread_stats[local_tid].tot_antimessages += lp_stats[lid].tot_antimessages;
+			thread_stats[local_tid].tot_events += lp_stats[lid].tot_events;
+			thread_stats[local_tid].committed_events += lp_stats[lid].committed_events;
+			thread_stats[local_tid].reprocessed_events += lp_stats[lid].reprocessed_events;
+			thread_stats[local_tid].tot_rollbacks += lp_stats[lid].tot_rollbacks;
+			thread_stats[local_tid].tot_ckpts += lp_stats[lid].tot_ckpts;
+			thread_stats[local_tid].ckpt_time += lp_stats[lid].ckpt_time;
+			thread_stats[local_tid].ckpt_mem += lp_stats[lid].ckpt_mem;
+			thread_stats[local_tid].tot_recoveries += lp_stats[lid].tot_recoveries;
+			thread_stats[local_tid].recovery_time += lp_stats[lid].recovery_time;
+			thread_stats[local_tid].event_time += lp_stats[lid].event_time;
+			thread_stats[local_tid].exponential_event_time += lp_stats[lid].exponential_event_time;
+			thread_stats[local_tid].idle_cycles += lp_stats[lid].idle_cycles;
 		}
-		thread_stats[tid].exponential_event_time /= n_prc_per_thread;
+		thread_stats[local_tid].exponential_event_time /= n_prc_per_thread;
 
 		// Compute derived statistics and dump everything
 		f = get_file(STAT_PER_THREAD, THREAD_STAT);
-		rollback_frequency = (thread_stats[tid].tot_rollbacks / thread_stats[tid].tot_events);
-		rollback_length = (thread_stats[tid].tot_rollbacks > 0
-				   ? (thread_stats[tid].tot_events - thread_stats[tid].committed_events) / thread_stats[tid].tot_rollbacks
+		rollback_frequency = (thread_stats[local_tid].tot_rollbacks / thread_stats[local_tid].tot_events);
+		rollback_length = (thread_stats[local_tid].tot_rollbacks > 0
+				   ? (thread_stats[local_tid].tot_events - thread_stats[local_tid].committed_events) / thread_stats[local_tid].tot_rollbacks
 				   : 0);
 		efficiency = (1 - rollback_frequency * rollback_length) * 100;
 
@@ -406,26 +406,26 @@ void statistics_stop(int exit_code) {
 		fprintf(f, "KERNEL ID ................. : %d \n", 		kid);
 		fprintf(f, "LPs HOSTED BY KERNEL....... : %d \n", 		n_prc);
 		fprintf(f, "TOTAL_THREADS ............. : %d \n", 		n_cores);
-		fprintf(f, "THREAD ID ................. : %d \n", 		tid);
+		fprintf(f, "THREAD ID ................. : %d \n", 		local_tid);
 		fprintf(f, "LPs HOSTED BY THREAD ...... : %d \n", 		n_prc_per_thread);
 		fprintf(f, "\n");
-		fprintf(f, "TOTAL EXECUTED EVENTS ..... : %.0f \n", 		thread_stats[tid].tot_events);
-		fprintf(f, "TOTAL COMMITTED EVENTS..... : %.0f \n", 		thread_stats[tid].committed_events);
-		fprintf(f, "TOTAL REPROCESSED EVENTS... : %.0f \n", 		thread_stats[tid].reprocessed_events);
-		fprintf(f, "TOTAL ROLLBACKS EXECUTED... : %.0f \n", 		thread_stats[tid].tot_rollbacks);
-		fprintf(f, "TOTAL ANTIMESSAGES......... : %.0f \n", 		thread_stats[tid].tot_antimessages);
+		fprintf(f, "TOTAL EXECUTED EVENTS ..... : %.0f \n", 		thread_stats[local_tid].tot_events);
+		fprintf(f, "TOTAL COMMITTED EVENTS..... : %.0f \n", 		thread_stats[local_tid].committed_events);
+		fprintf(f, "TOTAL REPROCESSED EVENTS... : %.0f \n", 		thread_stats[local_tid].reprocessed_events);
+		fprintf(f, "TOTAL ROLLBACKS EXECUTED... : %.0f \n", 		thread_stats[local_tid].tot_rollbacks);
+		fprintf(f, "TOTAL ANTIMESSAGES......... : %.0f \n", 		thread_stats[local_tid].tot_antimessages);
 		fprintf(f, "ROLLBACK FREQUENCY......... : %.2f %%\n",		rollback_frequency * 100);
 		fprintf(f, "ROLLBACK LENGTH............ : %.2f events\n",	rollback_length);
 		fprintf(f, "EFFICIENCY................. : %.2f %%\n",		efficiency);
-		fprintf(f, "AVERAGE EVENT COST......... : %.2f us\n",		thread_stats[tid].event_time / thread_stats[tid].tot_events);
-		fprintf(f, "AVERAGE EVENT COST (EMA)... : %.2f us\n",		thread_stats[tid].exponential_event_time);
-		fprintf(f, "AVERAGE CHECKPOINT COST.... : %.2f us\n",		thread_stats[tid].ckpt_time / thread_stats[tid].tot_ckpts);
-		fprintf(f, "AVERAGE RECOVERY COST...... : %.2f us\n",		(thread_stats[tid].tot_recoveries > 0 ? thread_stats[tid].recovery_time / thread_stats[tid].tot_recoveries : 0));
-		fprintf(f, "AVERAGE LOG SIZE........... : %s\n",		format_size(thread_stats[tid].ckpt_mem / thread_stats[tid].tot_ckpts));
-		fprintf(f, "IDLE CYCLES................ : %.0f\n",		thread_stats[tid].idle_cycles);
-		fprintf(f, "NUMBER OF GVT REDUCTIONS... : %.0f\n",		thread_stats[tid].gvt_computations);
-		fprintf(f, "SIMULATION TIME SPEED...... : %.2f units per GVT\n",thread_stats[tid].simtime_advancement);
-		fprintf(f, "AVERAGE MEMORY USAGE....... : %s\n",		format_size(thread_stats[tid].memory_usage / thread_stats[tid].gvt_computations));
+		fprintf(f, "AVERAGE EVENT COST......... : %.2f us\n",		thread_stats[local_tid].event_time / thread_stats[local_tid].tot_events);
+		fprintf(f, "AVERAGE EVENT COST (EMA)... : %.2f us\n",		thread_stats[local_tid].exponential_event_time);
+		fprintf(f, "AVERAGE CHECKPOINT COST.... : %.2f us\n",		thread_stats[local_tid].ckpt_time / thread_stats[local_tid].tot_ckpts);
+		fprintf(f, "AVERAGE RECOVERY COST...... : %.2f us\n",		(thread_stats[local_tid].tot_recoveries > 0 ? thread_stats[local_tid].recovery_time / thread_stats[local_tid].tot_recoveries : 0));
+		fprintf(f, "AVERAGE LOG SIZE........... : %s\n",		format_size(thread_stats[local_tid].ckpt_mem / thread_stats[local_tid].tot_ckpts));
+		fprintf(f, "IDLE CYCLES................ : %.0f\n",		thread_stats[local_tid].idle_cycles);
+		fprintf(f, "NUMBER OF GVT REDUCTIONS... : %.0f\n",		thread_stats[local_tid].gvt_computations);
+		fprintf(f, "SIMULATION TIME SPEED...... : %.2f units per GVT\n",thread_stats[local_tid].simtime_advancement);
+		fprintf(f, "AVERAGE MEMORY USAGE....... : %s\n",		format_size(thread_stats[local_tid].memory_usage / thread_stats[local_tid].gvt_computations));
 
 		if(exit_code == EXIT_FAILURE) {
 			fprintf(f, "\n--------- SIMULATION ABNORMALLY TERMINATED ----------\n");
@@ -610,7 +610,7 @@ void statistics_init(void) {
 			_mkdir(thread_dir);
 		}
 	}
-	sprintf(thread_dir, "%s/thread_%d_%d/", rootsim_config.output_dir, kid, tid);
+	sprintf(thread_dir, "%s/thread_%d_%d/", rootsim_config.output_dir, kid, local_tid);
 
 	// Allocate entries for file arrays (and set them to NULL, for later closing)
 	thread_files = rsalloc(sizeof(FILE **) * n_cores);
@@ -736,7 +736,7 @@ void statistics_post_lp_data(unsigned int lid, unsigned int type, double data) {
 				break;
 
 			case STAT_IDLE_CYCLES:
-				thread_stats[tid].idle_cycles++;
+				thread_stats[local_tid].idle_cycles++;
 				break;
 
 			case STAT_SILENT:
@@ -797,20 +797,20 @@ void statistics_post_other_data(unsigned int type, double data) {
 
 			statistics_flush_gvt(data);
 
-			thread_stats[tid].memory_usage += (double)getCurrentRSS();
-			thread_stats[tid].gvt_computations += 1.0;
-			simtime_advancement = data - thread_stats[tid].gvt_time;
+			thread_stats[local_tid].memory_usage += (double)getCurrentRSS();
+			thread_stats[local_tid].gvt_computations += 1.0;
+			simtime_advancement = data - thread_stats[local_tid].gvt_time;
 
-			if(D_DIFFER_ZERO(thread_stats[tid].simtime_advancement)) {
+			if(D_DIFFER_ZERO(thread_stats[local_tid].simtime_advancement)) {
 				// Exponential moving average
-				thread_stats[tid].simtime_advancement =
+				thread_stats[local_tid].simtime_advancement =
 					0.1 * simtime_advancement +
-					0.9 * thread_stats[tid].simtime_advancement;
+					0.9 * thread_stats[local_tid].simtime_advancement;
 			} else {
-				thread_stats[tid].simtime_advancement = simtime_advancement;
+				thread_stats[local_tid].simtime_advancement = simtime_advancement;
 			}
 
-			thread_stats[tid].gvt_time = data;
+			thread_stats[local_tid].gvt_time = data;
 
 			for(i = 0; i < n_prc_per_thread; i++) {
 				unsigned int lid = LPS_bound[i]->lid;
@@ -847,7 +847,7 @@ double statistics_get_data(unsigned int type, double data) {
 	switch(type) {
 
 		case STAT_GET_SIMTIME_ADVANCEMENT:
-			ret = thread_stats[tid].simtime_advancement;
+			ret = thread_stats[local_tid].simtime_advancement;
 			break;
 
 		case STAT_GET_EVENT_TIME_LP:


### PR DESCRIPTION
The `tid` is the global ID of a thread,
that is guaranteed to be unique among different kernels.

Problem
-------
Most of the times the code make use of the tid where instead the local thread ID should be used.

In a single kernel scenario the `tid` and `local_tid` concides, but on
a multi kernel run this will cause a LOT of problems and errors.

Fix & changes
-------------
The pairing function used for the global tid calculation is still the same
but has been refractored.

A `local_tid` variable is now exposed globally.

All the code that needs a local thread ID was changed
in order to make use the `local_tid` instead of the global `tid`.

Two helper function macros that implements the pairing function have been introduced:
 - `to_global_tid(kid, local_tid)`
 - `to_local_tid(global_tid)`

The usage of the pairing function indirectly impose a boundary constraints on both
the maximum number of local threads and the maximum number of kernels. Two constant
holding this limits have been exposed:
 - `MAX_KERNELS`
 - `MAX_THREADS_PER_KERNEL`

A sanity check on the number of threads has been added in the cli parsing phase