### PR TITLE
current_lp is not a gid

### DIFF
--- a/src/lib/topology.c
+++ b/src/lib/topology.c
@@ -15,6 +15,7 @@ unsigned int FindReceiver(int topology) {
 	unsigned int ret;
  	double u;
 	bool invalid = false;
+	unsigned int sender = LidToGid(current_lp);
 
  	// These must be unsigned. They are not checked for negative (wrong) values,
  	// but they would overflow, and are caught by a different check.
@@ -37,12 +38,12 @@ unsigned int FindReceiver(int topology) {
 		case TOPOLOGY_HEXAGON:
 
 			// Convert linear coords to hexagonal coords
-			x = current_lp % edge;
-			y = current_lp / edge;
+			x = sender % edge;
+			y = sender / edge;
 
 			// Very simple case!
 			if(n_prc_tot == 1) {
-				receiver = current_lp;
+				receiver = sender;
 				break;
 			}
 
@@ -99,12 +100,12 @@ unsigned int FindReceiver(int topology) {
 		case TOPOLOGY_SQUARE:
 
 			// Convert linear coords to square coords
-			x = current_lp % edge;
-			y = current_lp / edge;
+			x = sender % edge;
+			y = sender / edge;
 
 			// Very simple case!
 			if(n_prc_tot == 1) {
-				receiver = current_lp;
+				receiver = sender;
 				break;
 			}
 
@@ -148,12 +149,12 @@ unsigned int FindReceiver(int topology) {
 		case TOPOLOGY_TORUS:
 		
 			// Convert linear coords to square coords
-			x = current_lp % edge;
-			y = current_lp / edge;
+			x = sender % edge;
+			y = sender / edge;
 
 			// Very simple case!
 			if(n_prc_tot == 1) {
-				receiver = current_lp;
+				receiver = sender;
 				break;
 			}
 			
@@ -208,9 +209,9 @@ unsigned int FindReceiver(int topology) {
 			u = Random();
 
 			if (u < 0.5) {
-				receiver = current_lp - 1;
+				receiver = sender - 1;
 			} else {
-				receiver= current_lp + 1;
+				receiver= sender + 1;
 			}
 
    			if (receiver == -1) {
@@ -228,7 +229,7 @@ unsigned int FindReceiver(int topology) {
 
 		case TOPOLOGY_RING:
 
-			receiver= current_lp + 1;
+			receiver= sender + 1;
 
 			if ((unsigned int)receiver == n_prc_tot) {
 				receiver = 0;
@@ -239,7 +240,7 @@ unsigned int FindReceiver(int topology) {
 
 		case TOPOLOGY_STAR:
 
-			if (current_lp == 0) {
+			if (sender == 0) {
 				receiver = (int)(n_prc_tot * Random());
 			} else {
 				receiver = 0;
@@ -263,6 +264,7 @@ unsigned int FindReceiver(int topology) {
 int GetReceiver(int topology, int direction) {
 	int receiver = -1;
 	unsigned int x, y, nx, ny;
+	unsigned int sender = LidToGid(current_lp);
 
 	switch_to_platform_mode();
 
@@ -282,12 +284,12 @@ int GetReceiver(int topology, int direction) {
 		case TOPOLOGY_HEXAGON:
 
 			// Convert linear coords to hexagonal coords
-			x = current_lp % edge;
-			y = current_lp / edge;
+			x = sender % edge;
+			y = sender / edge;
 
 			// Very simple case!
 			if(n_prc_tot == 1) {
-				receiver = current_lp;
+				receiver = sender;
 				break;
 			}
 	
@@ -331,12 +333,12 @@ int GetReceiver(int topology, int direction) {
 		case TOPOLOGY_SQUARE:
 
 			// Convert linear coords to square coords
-			x = current_lp % edge;
-			y = current_lp / edge;
+			x = sender % edge;
+			y = sender / edge;
 
 			// Very simple case!
 			if(n_prc_tot == 1) {
-				receiver = current_lp;
+				receiver = sender;
 				break;
 			}
 
@@ -370,12 +372,12 @@ int GetReceiver(int topology, int direction) {
 			
 		case TOPOLOGY_TORUS:
 			// Convert linear coords to square coords
-			x = current_lp % edge;
-			y = current_lp / edge;
+			x = sender % edge;
+			y = sender / edge;
 
 			// Very simple case!
 			if(n_prc_tot == 1) {
-				receiver = current_lp;
+				receiver = sender;
 				break;
 			}
 
@@ -414,9 +416,9 @@ int GetReceiver(int topology, int direction) {
 		case TOPOLOGY_BIDRING:
 
 			if(direction == DIRECTION_W)
-				receiver = current_lp - 1;
+				receiver = sender - 1;
 			else if(direction == DIRECTION_E)
-				receiver = current_lp + 1;
+				receiver = sender + 1;
 			else
 				goto out;
 
@@ -433,7 +435,7 @@ int GetReceiver(int topology, int direction) {
 		case TOPOLOGY_RING:
 
 			if(direction == DIRECTION_E)
-				receiver= current_lp + 1;
+				receiver= sender + 1;
 			else
 				goto out;
 

--- a/src/scheduler/control.c
+++ b/src/scheduler/control.c
@@ -167,7 +167,7 @@ bool receive_control_msg(msg_t *msg) {
 				LPS[msg->receiver]->state = LP_STATE_READY;
 				LPS[msg->receiver]->wait_on_rendezvous = 0;
 			}
-			current_lp = msg->receiver;
+			current_lp = GidToLid(msg->receiver);
 			current_lvt = msg->timestamp;
 			force_LP_checkpoint(current_lp);
 			LogState(current_lp);

--- a/src/scheduler/scheduler.c
+++ b/src/scheduler/scheduler.c
@@ -58,7 +58,7 @@ LP_state **LPS = NULL;
 /// This is used to keep track of how many LPs were bound to the current KLT
 __thread unsigned int n_prc_per_thread;
 
-/// This global variable tells the simulator what is the LP currently being scheduled on the current worker thread
+/// This global variable tells the simulator what is the local id of the LP currently being scheduled on the current worker thread
 __thread unsigned int current_lp;
 
 /// This global variable tells the simulator what is the LP currently being scheduled on the current worker thread
@@ -191,7 +191,7 @@ static void LP_main_loop(void *args) {
 
 		#ifdef EXTRA_CHECKS
 		if(current_evt->size > 0) {
-			hash1 = XXH64(current_evt->event_content, current_evt->size, current_lp);
+			hash1 = XXH64(current_evt->event_content, current_evt->size, LidToGid(current_lp));
 		}
 		#endif
 
@@ -207,11 +207,11 @@ static void LP_main_loop(void *args) {
 
 		#ifdef EXTRA_CHECKS
 		if(current_evt->size > 0) {
-			hash2 = XXH64(current_evt->event_content, current_evt->size, current_lp);
+			hash2 = XXH64(current_evt->event_content, current_evt->size, LidToGid(current_lp));
 		}
 
 		if(hash1 != hash2) {
-                        rootsim_error(true, "Error, LP %d has modified the payload of event %d during its processing. Aborting...\n", current_lp, current_evt->type);
+                        rootsim_error(true, "Error, LP %d has modified the payload of event %d during its processing. Aborting...\n", LidToGid(current_lp), current_evt->type);
 		}
 		#endif
 


### PR DESCRIPTION
`current_lp` is a thread variable and should always points to the current LP being scheduled by the current thread. In the case no LP is being scheduled it should point to `IDLE_PROCESS`.

Reasobably it should be the global id of the LP (`gid`), but at the moment for practical and historical reasons it points to the local id of the current LP (`lid`).

The problem is that in some point of the code is treated as a `gid` even if it is a `lid`.

This commit fix all the code points in which `current_lp` is treated as local LP id

related to #44 