### PR TITLE
 gvt: do not recalculate LPs time barrier multiple times

### DIFF
--- a/src/gvt/fossil.c
+++ b/src/gvt/fossil.c
@@ -82,7 +82,7 @@ void fossil_collection(unsigned int lid, simtime_t time_barrier) {
 *
 * @author Francesco Quaglia
 */
-void adopt_new_gvt(simtime_t new_gvt, simtime_t new_min_barrier) {
+void adopt_new_gvt(simtime_t new_gvt) {
 	register unsigned int i;
 
 	state_t *time_barrier_pointer[n_prc_per_thread];
@@ -94,7 +94,7 @@ void adopt_new_gvt(simtime_t new_gvt, simtime_t new_min_barrier) {
 
 	// Precompute the time barrier for each process
 	for (i = 0; i < n_prc_per_thread; i++) {
-		time_barrier_pointer[i] = find_time_barrier(LPS_bound[i]->lid, new_min_barrier);
+		time_barrier_pointer[i] = find_time_barrier(LPS_bound[i]->lid, new_gvt);
 	}
 
 	// If needed, call the CCGS subsystem

--- a/src/gvt/fossil.c
+++ b/src/gvt/fossil.c
@@ -54,8 +54,6 @@ void fossil_collection(unsigned int lid, simtime_t time_barrier) {
 	msg_t *last_kept_event;
 	double committed_events;
 
-	time_barrier = 0.7 * time_barrier;
-
 	// State list must be handled differently, as nodes point to malloc'd
 	// nodes. We therefore manually scan the list and free the memory.
 	while( (state = list_head(LPS[lid]->queue_states)) != NULL && state->lvt < time_barrier) {

--- a/src/gvt/gvt.h
+++ b/src/gvt/gvt.h
@@ -42,6 +42,6 @@ extern simtime_t gvt_operations(void);
 inline extern simtime_t get_last_gvt(void);
 
 /* API from fossil.c */
-extern void adopt_new_gvt(simtime_t, simtime_t);
+extern void adopt_new_gvt(simtime_t);
 
 #endif


### PR DESCRIPTION
the gvt phases were used to make all the threads agreed on a global
minimum time barrier. This was achieved by recalculating the minimum time barrier
for each LPs in phase A and phase B.

It is not necessary that all the threads agreed on a minimum time
barrier. We need to calculate one different time barrier for each LP;
this needs to be done just once, after all the threads had agreed on the GVT.