### PR TITLE
new cli flag: --no-core-binding

### DIFF
--- a/src/arch/thread.c
+++ b/src/arch/thread.c
@@ -73,7 +73,8 @@ static void *__helper_create_thread(void *arg) {
 
 
 	// Set the affinity on a CPU core, for increased performance
-	set_affinity(local_tid);
+	if(rootsim_config.core_binding)
+		set_affinity(local_tid);
 
 	// Now get into the real thread's entry point
 	real_arg->start_routine(real_arg->arg);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -176,6 +176,7 @@ typedef struct _simulation_configuration {
 	enum stat_levels stats;		/// Produce performance statistic file (default STATS_ALL)
 	bool serial;			// If the simulation must be run serially
 	seed_type set_seed;		/// The master seed to be used in this run
+	bool core_binding;		/// Bind threads to specific core ( reduce context switches and cache misses )
 
 #ifdef HAVE_PREEMPTION
 	bool disable_preemption;	/// If compiled for preemptive Time Warp, it can be disabled at runtime

--- a/src/core/init.c
+++ b/src/core/init.c
@@ -117,6 +117,7 @@ static int parse_cmd_line(int argc, char **argv) {
 	rootsim_config.verbose = VERBOSE_INFO;
 	rootsim_config.stats = STATS_ALL;
 	rootsim_config.serial = false;
+	rootsim_config.core_binding = true;
 
 	#ifdef HAVE_PREEMPTION
 	rootsim_config.disable_preemption = false;
@@ -299,6 +300,9 @@ static int parse_cmd_line(int argc, char **argv) {
 			case OPT_SERIAL:
 				rootsim_config.serial = true;
 				break;
+
+			case OPT_NO_CORE_BINDING:
+				rootsim_config.core_binding = false;
 
 			#ifdef HAVE_PREEMPTION
 			case OPT_PREEMPTION:

--- a/src/core/init.h
+++ b/src/core/init.h
@@ -32,13 +32,14 @@
 #define OPT_STATS		19
 #define OPT_SEED		20
 #define OPT_SERIAL		21
+#define OPT_NO_CORE_BINDING	22
 
 #ifdef HAVE_PREEMPTION
-#define OPT_PREEMPTION		22
+#define OPT_PREEMPTION		23
 #endif
 
 #ifdef HAVE_PARALLEL_ALLOCATOR
-#define OPT_ALLOCATOR		23
+#define OPT_ALLOCATOR		24
 #endif
 
 // TODO: a vector of vector with text name of numerical options, which should be used for parsing options and for displaying names
@@ -68,6 +69,7 @@ static char *opt_desc[] = {
 	"Level of detail in the output statistics",
 	"Manually specify the initial random seed",
 	"Run a serial simulation (using Calendar Queues)",
+	"Disable the binding of threads to specific phisical processing cores",
 
 #ifdef HAVE_PREEMPTION
 	"Disable Preemptive Time Warp",
@@ -104,6 +106,8 @@ static struct option long_options[] = {
 	{"seed",		required_argument,	0, OPT_SEED},
 	{"serial",		no_argument,		0, OPT_SERIAL},
 	{"sequential",		no_argument,		0, OPT_SERIAL},
+	{"no-core-binding",	no_argument,		0, OPT_NO_CORE_BINDING},
+
 	
 #ifdef HAVE_PREEMPTION
 	{"no-preemption",	no_argument,		0, OPT_PREEMPTION},

--- a/src/main.c
+++ b/src/main.c
@@ -156,9 +156,10 @@ static void *main_simulation_loop(void *arg) {
 */
 int main(int argc, char **argv) {
 
-	set_affinity(0);
-
 	SystemInit(argc, argv);
+	
+	if(rootsim_config.core_binding)
+		set_affinity(0);
 
 	if(rootsim_config.serial) {
 		serial_simulation();


### PR DESCRIPTION
Added new cli flag `--no-core-binding` that can be used to disable the binding of the
threads to the phisical processing cores. It could be useful in the case
other external binding approach need to be used and in the case
that more then one kernel is executing on the same machine.