### PR TITLE
ECS: Missing headers and cleanup

### DIFF
--- a/models/pcs/application.c
+++ b/models/pcs/application.c
@@ -204,8 +204,8 @@ void ProcessEvent(unsigned int me, simtime_t now, int event_type, event_content_
 			deallocation(me, state, event_content->channel, now);
 
 			new_event_content.call_term_time =  event_content->call_term_time;
-      new_event_content.dummy = &(state->dummy);
-      new_event_content.from = me;
+			new_event_content.dummy = &(state->dummy);
+			new_event_content.from = me;
 			ScheduleNewEvent(event_content->cell, now, HANDOFF_RECV, &new_event_content, sizeof(new_event_content));
 			break;
 
@@ -213,12 +213,9 @@ void ProcessEvent(unsigned int me, simtime_t now, int event_type, event_content_
 			state->arriving_handoffs++;
 			state->arriving_calls++;
 
-      ran = Random();
-      printf("Generated random sample %f\n", ran);
+			ran = Random();
 
 			if(me == 1 && ran < 0.3 && event_content->from == 2){//&& state->dummy_flag == false) {
-        //printf("Starting synch with %d\n", event_content->from);
-        fflush(stdout);
 				*(event_content->dummy) = 1;
 				state->dummy_flag = true;
 			}
@@ -231,7 +228,6 @@ void ProcessEvent(unsigned int me, simtime_t now, int event_type, event_content_
 				new_event_content.channel = allocation(state);
 				new_event_content.call_term_time = event_content->call_term_time;
 
-//				printf("(%d) allocation %d at %f\n", me, new_event_content.channel, now);
 
 				switch (CELL_CHANGE_DISTRIBUTION) {
 					case UNIFORM:
@@ -244,7 +240,7 @@ void ProcessEvent(unsigned int me, simtime_t now, int event_type, event_content_
 						break;
 					default:
 						handoff_time = now+
-			    			(simtime_t) (5 * Random());
+						(simtime_t) (5 * Random());
 				}
 
 				if(new_event_content.call_term_time < handoff_time ) {
@@ -259,7 +255,7 @@ void ProcessEvent(unsigned int me, simtime_t now, int event_type, event_content_
 			break;
 
 
-		case FADING_RECHECK:
+				case FADING_RECHECK:
 
 /*
 			if(state->check_fading)

--- a/src/communication/communication.c
+++ b/src/communication/communication.c
@@ -84,7 +84,7 @@ void ParallelScheduleNewEvent(unsigned int gid_receiver, simtime_t timestamp, un
 	msg_t event;
 	switch_to_platform_mode();
 
-  // In Silent execution, we do not send again already sent messages
+	// In Silent execution, we do not send again already sent messages
 	if(LPS[current_lp]->state == LP_STATE_SILENT_EXEC) {
 		return;
 	}
@@ -100,10 +100,10 @@ void ParallelScheduleNewEvent(unsigned int gid_receiver, simtime_t timestamp, un
 		rootsim_error(true, "LP %u is trying to generate an event (type %d) to %u in the past! (Current LVT = %f, generated event's timestamp = %f) Aborting...\n", current_lp, event_type, gid_receiver, lvt(current_lp), timestamp);
 	}
 
-  // Check if the event type is mapped to an internal control message
-  if(event_type >= MIN_VALUE_CONTROL) {
-          rootsim_error(true, "LP %u is generating an event with type %d which is a reserved type. Switch event type to a value less than %d. Aborting...\n", current_lp, event_type, MIN_VALUE_CONTROL);
-  }
+	// Check if the event type is mapped to an internal control message
+	if(event_type >= MIN_VALUE_CONTROL) {
+		rootsim_error(true, "LP %u is generating an event with type %d which is a reserved type. Switch event type to a value less than %d. Aborting...\n", current_lp, event_type, MIN_VALUE_CONTROL);
+	}
 
 
 	// Copy all the information into the event structure
@@ -164,11 +164,8 @@ void send_antimessages(unsigned int lid, simtime_t after_simtime) {
 
 	// Get the first message header with a timestamp <= after_simtime
 	anti_msg = list_tail(LPS[lid]->queue_out);
-//	printf("\tlid: %d %f (tail)\n", lid, (anti_msg != NULL ? anti_msg->timestamp : -1.0));
-//	while(anti_msg != NULL && anti_msg->send_time > after_simtime) {
 	while(anti_msg != NULL && anti_msg->send_time > after_simtime){
 		anti_msg = list_prev(anti_msg);
-		//printf("\tlid: %d %f\n", lid, (anti_msg != NULL ? anti_msg->timestamp : -1.0));
 	}
 	// The next event is the first event with a sendtime > after_simtime, if any.
 	// Explicitly consider the case in which all anti messages should be sent.
@@ -180,7 +177,6 @@ void send_antimessages(unsigned int lid, simtime_t after_simtime) {
 		anti_msg = list_next(anti_msg);
 	}
 
-  //printf("\t lid: %d, anti msg type: %d\n",lid,anti_msg->type);
 	// Now send all antimessages
 	while(anti_msg != NULL) {
 		bzero(&msg, sizeof(msg_t));
@@ -191,25 +187,6 @@ void send_antimessages(unsigned int lid, simtime_t after_simtime) {
 		msg.send_time = anti_msg->send_time;
 		msg.mark = anti_msg->mark;
 		msg.message_kind = negative;
-    //printf("what the fuck am i sending?%d\n",anti_msg->type);
-    /* printf("Message Content:" */
-							/* "sender: %d\n" */
-							/* "receiver: %d\n" */
-							/* "type: %d\n" */
-							/* "timestamp: %f\n" */
-							/* "send time: %f\n" */
-							/* "is antimessage %d\n" */
-							/* "mark: %llu\n" */
-							/* "rendezvous mark %llu\n\n", */
-							/* msg.sender, */
-							/* msg.receiver, */
-							/* msg.type, */
-							/* msg.timestamp, */
-							/* msg.send_time, */
-							/* msg.message_kind, */
-							/* msg.mark, */
-							/* msg.rendezvous_mark); */
-						/* fflush(stdout); */
 		Send(&msg);
 
 		// Remove the already sent antimessage from output queue
@@ -256,29 +233,6 @@ int comm_finalize(void) {
 * @author Francesco Quaglia
 */
 void Send(msg_t *msg) {
-
-/*
-						printf("Message Content:"
-							"sender: %d\n"
-							"receiver: %d\n"
-							"type: %d\n"
-							"timestamp: %f\n"
-							"send time: %f\n"
-							"is antimessage %d\n"
-							"mark: %llu\n"
-							"rendezvous mark %llu\n\n",
-							msg->sender,
-							msg->receiver,
-							msg->type,
-							msg->timestamp,
-							msg->send_time,
-							msg->message_kind,
-							msg->mark,
-							msg->rendezvous_mark);
-						fflush(stdout);
-*/
-  //if(msg->type < 0 && msg->message_kind == 1)
-   // printf("sender %d receiver % d antimessage %d randezvous mark %llu msg type %d\n",msg->sender, msg->receiver,msg->message_kind,msg->rendezvous_mark,msg->type);
 	// Check whether the message recepient is local or remote
 	if(GidToKernel(msg->receiver) == kid) { // is local
 		insert_bottom_half(msg);
@@ -358,8 +312,7 @@ int messages_checking(void) {
 		// Receive the message
 	    	(void)comm_recv((char*)&msg, sizeof(msg_t), MPI_CHAR, MPI_ANY_SOURCE, MSG_EVENT, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
-		// For GVT Operations:0
-    //
+		// For GVT Operations
 		gvt_messages_rcvd[GidToKernel(msg.sender)] += 1;
 
 
@@ -413,15 +366,14 @@ void send_outgoing_msgs(unsigned int lid) {
 		Send(msg);
 
 		// Register the message in the sender's output queue, for antimessage management
-    bzero(&msg_hdr, sizeof(msg_hdr_t));
+		bzero(&msg_hdr, sizeof(msg_hdr_t));
 		msg_hdr.sender = msg->sender;
 		msg_hdr.receiver = msg->receiver;
 		msg_hdr.timestamp = msg->timestamp;
 		msg_hdr.send_time = msg->send_time;
 		msg_hdr.mark = msg->mark;
-    msg_hdr.type = msg->type; //ADDED BY MATTEO
-    msg_hdr.rendezvous_mark = msg->rendezvous_mark;
-    //printf("sending msg header with type %d\n",msg->type);
+		msg_hdr.type = msg->type; //ADDED BY MATTEO
+		msg_hdr.rendezvous_mark = msg->rendezvous_mark;
 		(void)list_insert(lid, LPS[lid]->queue_out, send_time, &msg_hdr);
 	}
 

--- a/src/gvt/fossil.c
+++ b/src/gvt/fossil.c
@@ -54,8 +54,6 @@ void fossil_collection(unsigned int lid, simtime_t time_barrier) {
 	msg_t *last_kept_event;
 	double committed_events;
 
-//  printf("Fossil Collection for LP %d\n", lid);
-
 	// State list must be handled differently, as nodes point to malloc'd
 	// nodes. We therefore manually scan the list and free the memory.
 	while( (state = list_head(LPS[lid]->queue_states)) != NULL && state->lvt < time_barrier) {

--- a/src/lib/numerical.c
+++ b/src/lib/numerical.c
@@ -62,7 +62,7 @@ static double do_random(void) {
 	*seed2 = 18000u * (*seed2 & 0xFFFFu) + (*seed2 >> 16u);
 
 	// The magic number below is 1/(2^32 + 2).
- 	// The result is strictly between 0 and 1.
+	// The result is strictly between 0 and 1.
 	return (((*seed1 << 16u) + (*seed1 >> 16u) + *seed2) + 1.0) * 2.328306435454494e-10;
 
 }

--- a/src/main.c
+++ b/src/main.c
@@ -137,11 +137,6 @@ static void *main_simulation_loop(void *arg) {
 				printf("TIME BARRIER %f\n", my_time_barrier);
 				#endif
 
-        int xzy;
-        for(xzy = 0; xzy < n_prc_tot; xzy++) {
-          printf("LP %d in state %d\n", xzy, LPS[xzy]->state);
-        }
-
 				fflush(stdout);
 			}
 		}

--- a/src/mm/bh.c
+++ b/src/mm/bh.c
@@ -170,20 +170,16 @@ int insert_BH(int lid, void* msg, int size) {
 	// as in this way the critical section is much shorter
 	if(residual_store < needed_store) {
 
-		//printf("Reallocating...\n");
-
 		spin_lock(&bh_read[lid]);
 
 		old_buffer = bh_maps[lid].live_bh;
 
 		// Update stable pointers
 		if(bh_maps[lid].actual_bh_addresses[0] == old_buffer) {
-			//printf("first if\n");
 			old_size = bh_maps[lid].current_pages[0];
 			bh_maps[lid].current_pages[0] *= 2;
 			new_buffer = bh_maps[lid].actual_bh_addresses[0] = allocate_pages(bh_maps[lid].current_pages[0]);
 		} else {
-			//printf("second if\n");
 			old_size = bh_maps[lid].current_pages[1];
 			bh_maps[lid].current_pages[1] *= 2;
 			new_buffer = bh_maps[lid].actual_bh_addresses[1] = allocate_pages(bh_maps[lid].current_pages[1]);

--- a/src/mm/bh.c
+++ b/src/mm/bh.c
@@ -33,6 +33,7 @@
 #include <arch/atomic.h>
 #include <mm/bh.h>
 #include <mm/mm.h>
+#include <mm/dymelor.h>
 #include <datatypes/list.h>
 
 

--- a/src/mm/buddy.c
+++ b/src/mm/buddy.c
@@ -70,7 +70,6 @@ void *get_pages(unsigned int lid){
   /* } */
   size_t node_size;
   void *current_bs;
-//  void *final_bs;
   unsigned idx;
   struct _buddy *self;
   int offset;
@@ -86,18 +85,13 @@ void *get_pages(unsigned int lid){
       node_size <<= 1;    /* node_size *= 2; */
 
       if (self->longest[idx] == 0) {
-          /* printf("longest[%d] = %zu with size: %zu\n", idx,self->longest[idx],node_size); */
 
           offset = (idx + 1) * node_size - self->size;
           current_bs = (void*)((char*)old_bs + offset*BUDDY_GRANULARITY);
           num_pages = node_size/PAGE_SIZE +1;
-//          final_bs = (void*)((char*)old_bs + offset*BUDDY_GRANULARITY + (node_size/PAGE_SIZE + 1)*BUDDY_GRANULARITY);
 
           while (num_pages != 0){
             current_bs = (void *)((char *)current_bs + BUDDY_GRANULARITY); //TODO: save those addresses to be returned. */
-            /* printf("\n\tCurrent page address is: %p target page address: %p, num of pages %d\n",old_bs,curr_bs,node_size/PAGE_SIZE); */
-            /* printf("\t\nallocated pages: %d  with address %p page size is: %d\n",num_pages,old_bs, PAGE_SIZE); */
-            //printf("\t\n base pointer is: %p, current address %p  ending address: %p, allocated size: %d, num of pages: %d\n", mem_areas[lid], current_bs, final_bs, node_size,num_pages);
             num_pages--;
           }
      }
@@ -171,14 +165,8 @@ static long long buddy_alloc(struct _buddy *self, size_t size) {
     }
     size = POWEROF2(size);
 
-    //if(size > 15000000)
-    //  printf("Buddy is mapping the request to %d bytes of memory\n", size);
-    fflush(stdout);
-
     unsigned idx = 0;
     if (self->longest[idx] < size) {
-    //    printf("NON C'HO MEMORIAAAAA\n");
-        fflush(stdout);
         return -1;
     }
 
@@ -192,8 +180,6 @@ static long long buddy_alloc(struct _buddy *self, size_t size) {
     self->longest[idx] = 0;
     int offset = (idx + 1) * node_size - self->size;
 
-    //if(size > 15000000)
- //     printf("occupied idx: %u with size: %zu, offset is: %d\n", idx,node_size,offset);
     while (idx) {
         idx = parent(idx);
         self->longest[idx] = max(self->longest[left_child(idx)], self->longest[right_child(idx)]);
@@ -239,41 +225,24 @@ static void buddy_free(struct _buddy *self, int offset) {
 }
 
 void *pool_get_memory(unsigned int lid, size_t size) {
-	long long offset, 
-            displacement;
+	long long offset,
+		displacement;
 	size_t fragments;
-
-  //printf("Requesting %d bytes of memory\n", size);
 
 	// Get a number of fragments to contain 'size' bytes
 	// The operation involves a fast positive integer round up
 	fragments = 1 + ((size - 1) / BUDDY_GRANULARITY);
-  offset = buddy_alloc(buddies[lid], fragments);
+	offset = buddy_alloc(buddies[lid], fragments);
 	displacement = offset * BUDDY_GRANULARITY;
 
-  if(offset == -1)
+	if(offset == -1)
 		return NULL;
 
-/*
-  void * ptr = (void *)((char *)mem_areas[lid] + displacement);
-  printf("(%d)[%d] pool_get_memory returns %p\n", tid, lid, ptr);
-  if(ptr < 0x50000000000 || 1) {
-    printf("\tsize: %lu\n", size);
-    printf("\tfragments: %lu\n", fragments);
-    printf("\toffset: %llu\n", offset);
-    printf("\tdisplacement: %llu\n", displacement);
-    printf("\tdisplacements[%d]: %llu\n", lid, displacements[lid]);
-    printf("\tmem_areas[%d]: %p\n", lid, mem_areas[lid]);
-  }
-*/
-  //if(size > 15000000)
-  //  abort();
+	if(displacements[lid] < offset){
+		displacements[lid] = offset;
+	}
 
-  if(displacements[lid] < offset){
-    displacements[lid] = offset;
-  }
-
-  return (void *)((char *)mem_areas[lid] + displacement);
+	return (void *)((char *)mem_areas[lid] + displacement);
 }
 
 
@@ -316,20 +285,17 @@ bool allocator_init(void) {
 	// These are a vector of pointers which are later initialized
 	buddies = rsalloc(sizeof(struct _buddy *) * n_prc);
 	mem_areas = rsalloc(sizeof(void *) * n_prc);
-  displacements = rsalloc(sizeof(long long) *n_prc);
-  //printf("Initializing LP memory allocator... ");
+	displacements = rsalloc(sizeof(long long) *n_prc);
 
-  segment_allocator_init(n_prc); //ADDED BY MATTEO.
+	segment_allocator_init(n_prc); //ADDED BY MATTEO.
 
-  for (i = 0; i < n_prc; i++){
-    displacements[i] = 0;
+	for (i = 0; i < n_prc; i++){
+		displacements[i] = 0;
 		buddies[i] = buddy_new(PER_LP_PREALLOCATED_MEMORY / BUDDY_GRANULARITY);
 		mem_areas[i] = get_base_pointer(i);
-    if(mem_areas[i] == NULL)
+		if(mem_areas[i] == NULL)
 			rootsim_error(true, "Unable to initialize memory for LP %d. Aborting...\n",i);
 	}
-
-	//printf("done\n");
 
 #ifdef HAVE_NUMA
 	numa_init();
@@ -341,5 +307,3 @@ bool allocator_init(void) {
 
 	return true;
 }
-
-

--- a/src/mm/buddy.c
+++ b/src/mm/buddy.c
@@ -32,6 +32,7 @@
 
 #include <mm/dymelor.h>
 #include <mm/mm.h>
+#include <mm/bh.h>
 
 
 static struct _buddy **buddies;

--- a/src/mm/dymelor.c
+++ b/src/mm/dymelor.c
@@ -290,7 +290,7 @@ void *do_malloc(unsigned int lid, malloc_state *mem_pool, size_t size) {
 		m_area->self_pointer = (malloc_area *)pool_get_memory(lid, area_size);
 		#else
 		m_area->self_pointer = rsalloc(area_size);
-    bzero(m_area->self_pointer, area_size);
+		bzero(m_area->self_pointer, area_size);
 		#endif
 
 		if(m_area->self_pointer == NULL){

--- a/src/mm/ecs.c
+++ b/src/mm/ecs.c
@@ -142,7 +142,7 @@ void lp_alloc_thread_init(void) {
 	lp_memory_ioctl_info.mapped_processes = n_prc;
 
 	callback_function =  rootsim_cross_state_dependency_handler;
-	lp_memory_ioctl_info.callback = callback_function;
+	lp_memory_ioctl_info.callback = (ulong) callback_function;
 
 	// TODO: this function is called by each worker thread. Does calling SET_VM_RANGE cause
   // a memory leak into kernel space?

--- a/src/mm/state.c
+++ b/src/mm/state.c
@@ -60,15 +60,13 @@ bool LogState(unsigned int lid) {
 	state_t new_state; // If inserted, list API makes a copy of this
 
 	if(is_blocked_state(LPS[lid]->state)) {
-		//printf("avoidedd saving state %llu of LP %u\n",LPS[lid]->state,lid);
-    return take_snapshot;
+		return take_snapshot;
 	}
 
 	// Keep track of the invocations to LogState
 	LPS[lid]->from_last_ckpt++;
 
 	if(LPS[lid]->state_log_forced) {
-    printf("(forced) ");
 		LPS[lid]->state_log_forced = false;
 		LPS[lid]->from_last_ckpt = 0;
 
@@ -94,20 +92,17 @@ bool LogState(unsigned int lid) {
 			rootsim_error(true, "State saving mode not supported.");
 	}
 
-    skip_switch:
+skip_switch:
 
 	// Shall we take a log?
 	if (take_snapshot) {
-
-    printf("LP %d taking snapshot at %f, bound with mark %llu rm %llu\n",
-          lid, lvt(lid), LPS[lid]->bound->mark, LPS[lid]->bound->rendezvous_mark);
-    fflush(stdout);
 
 		// Take a log and set the associated LVT
 		new_state.log = log_state(lid);
 		new_state.lvt = lvt(lid);
 		new_state.last_event = LPS[lid]->bound;
 		new_state.state = LPS[lid]->state;
+
 		// We take as the buffer state the last one associated with a SetState() call, if any
 		new_state.base_pointer = LPS[lid]->current_base_pointer;
 
@@ -124,12 +119,11 @@ void RestoreState(unsigned int lid, state_t *restore_state) {
 	log_restore(lid, restore_state);
 	LPS[lid]->current_base_pointer = restore_state->base_pointer;
 	LPS[lid]->state = restore_state->state;
-  //printf("ROLLBACKING LP %d TO STATE %llu\n",lid,LPS[lid]->state);
-  #ifdef HAVE_CROSS_STATE
+#ifdef HAVE_CROSS_STATE
 	LPS[lid]->ECS_index = 0;
 	LPS[lid]->wait_on_rendezvous = 0;
 	LPS[lid]->wait_on_object = 0;
-	#endif
+#endif
 }
 
 
@@ -154,9 +148,6 @@ unsigned int silent_execution(unsigned int lid, void *state_buffer, msg_t *evt, 
 	old_state = LPS[lid]->state;
 	LPS[lid]->state = LP_STATE_SILENT_EXEC;
 
-//  printf("%llu - LP %d starting silent execution from %f to %f\n", CLOCK_READ(), lid, evt->timestamp, final_evt->timestamp);
-//  fflush(stdout);
-
 	// This is true if the restored state was taken after the new bound
 	if(evt == final_evt)
 		goto out;
@@ -167,25 +158,20 @@ unsigned int silent_execution(unsigned int lid, void *state_buffer, msg_t *evt, 
 	// Reprocess events. Outgoing messages are explicitly discarded, as this part of
 	// the simulation has been already executed at least once
 	while(evt != NULL && evt != final_evt) {
-//    printf("%llu - LP %d reprocessing evt %d at %f\n", CLOCK_READ(), lid, evt->type, evt->timestamp);
-    fflush(stdout);
 
-	  if(!reprocess_control_msg(evt)) {
-		  	evt = list_next(evt);
-			  continue;
-  		}
+		if(!reprocess_control_msg(evt)) {
+			evt = list_next(evt);
+			continue;
+		}
 
-     events++;
-//  	printf("[%d] Old_state: %lu\n",lid,old_state);
-//    printf("EVT timestamp %f, FINALEVT timestamp %f, current time %f\n",evt->timestamp, final_evt->timestamp,lvt(lid));
-//		printf("while silent executing calling activate_lp for LP %u in state %u..\n",lid,LPS[lid]->state);
-    activate_LP(lid, evt->timestamp, evt, state_buffer);
+		events++;
+		activate_LP(lid, evt->timestamp, evt, state_buffer);
 		evt = list_next(evt);
 	}
 
-    out:
-      LPS[lid]->state = old_state;
-      return events;
+out:
+	LPS[lid]->state = old_state;
+	return events;
 }
 
 
@@ -214,8 +200,6 @@ void rollback(unsigned int lid) {
 		return;
 	}
 
-  printf("%llu - LP %d rolling back\n", CLOCK_READ(), lid);
-  fflush(stdout);
 
 	// Discard any possible execution state related to a blocked execution
 	#ifdef ENABLE_ULT
@@ -225,7 +209,7 @@ void rollback(unsigned int lid) {
 	statistics_post_lp_data(lid, STAT_ROLLBACK, 1.0);
 
 	last_correct_event = LPS[lid]->bound;
-  // Send antimessages
+	// Send antimessages
 	send_antimessages(lid, last_correct_event->timestamp);
 
 	// Find the state to be restored, and prune the wrongly computed states
@@ -241,17 +225,13 @@ void rollback(unsigned int lid) {
 	RestoreState(lid, restore_state);
 
 	last_restored_event = restore_state->last_event;
-  printf("While rollbacking,%d last restored event has ts: %f mark: %llu, rv mark: %llu\n",lid,last_restored_event->timestamp,last_restored_event->mark, last_restored_event->rendezvous_mark);
-  reprocessed_events = silent_execution(lid, LPS[lid]->current_base_pointer, last_restored_event, last_correct_event);
+	reprocessed_events = silent_execution(lid, LPS[lid]->current_base_pointer, last_restored_event, last_correct_event);
 	statistics_post_lp_data(lid, STAT_SILENT, (double)reprocessed_events);
 
-  // TODO: silent execution resets the LP state to the previous
-  // value, so it should be the last function to be called within rollback()
+	// TODO: silent execution resets the LP state to the previous
+	// value, so it should be the last function to be called within rollback()
 	// Control messages must be rolled back as well
 	rollback_control_message(lid, last_correct_event->timestamp);
-
-  printf("%llu - LP %d rollback complete\n", CLOCK_READ(), lid);
-  fflush(stdout);
 }
 
 

--- a/src/queues/queues.c
+++ b/src/queues/queues.c
@@ -178,25 +178,6 @@ restart:
 
 			lid_receiver = GidToLid(msg_to_process->receiver);
 
-						/*printf("Message Content:"
-							"sender: %d\n"
-							"receiver: %d\n"
-							"type: %d\n"
-							"timestamp: %f\n"
-							"send time: %f\n"
-							"is antimessage %d\n"
-							"mark: %llu\n"
-							"rendezvous mark %llu\n\n",
-							msg_to_process->sender,
-							msg_to_process->receiver,
-							msg_to_process->type,
-							msg_to_process->timestamp,
-							msg_to_process->send_time,
-							msg_to_process->message_kind,
-							msg_to_process->mark,
-							msg_to_process->rendezvous_mark);
-						fflush(stdout);*/
-
 			if(msg_to_process->timestamp < get_last_gvt())
 				printf("ERRORE\n");
 
@@ -229,7 +210,7 @@ restart:
 
 					if(matched_msg == NULL) {
 						rootsim_error(false, "LP %d Received an antimessage with mark %llu at LP %u from LP %u, but no such mark found in the input queue!\n", LPS_bound[i]->lid, msg_to_process->mark, msg_to_process->receiver, msg_to_process->sender);
-						/*printf("Message Content:"
+						printf("Message Content:"
 							"sender: %d\n"
 							"receiver: %d\n"
 							"type: %d\n"
@@ -246,7 +227,7 @@ restart:
 							msg_to_process->message_kind,
 							msg_to_process->mark,
 							msg_to_process->rendezvous_mark);
-						fflush(stdout);*/
+						fflush(stdout);
 						abort();
 					} else {
 
@@ -258,15 +239,12 @@ restart:
 //							}
 
 							LPS[lid_receiver]->bound = list_prev(matched_msg);
-							while ((LPS[lid_receiver]->bound != NULL) &&
-							       D_EQUAL(LPS[lid_receiver]->bound->timestamp, msg_to_process->timestamp)){
-                LPS[lid_receiver]->bound = list_prev(LPS[lid_receiver]->bound);
+							while((LPS[lid_receiver]->bound != NULL) &&
+									D_EQUAL(LPS[lid_receiver]->bound->timestamp, msg_to_process->timestamp)){
+								LPS[lid_receiver]->bound = list_prev(LPS[lid_receiver]->bound);
 							}
 
 							LPS[lid_receiver]->state = LP_STATE_ROLLBACK;
-
-              printf("%llu - Process %d set to STATE_ROLLBACK due to msg from %d at time %f type %d (antimessage)\n", CLOCK_READ(), lid_receiver, msg_to_process->sender, msg_to_process->timestamp, msg_to_process->type);
-              fflush(stdout);
 
 						}
 
@@ -286,15 +264,12 @@ restart:
 					if(msg_to_process->timestamp < lvt(lid_receiver)) {
 
 						LPS[lid_receiver]->bound = list_prev(msg_to_process);
-						while ((LPS[lid_receiver]->bound != NULL) &&
-						  D_EQUAL(LPS[lid_receiver]->bound->timestamp, msg_to_process->timestamp)){
+						while((LPS[lid_receiver]->bound != NULL) &&
+								D_EQUAL(LPS[lid_receiver]->bound->timestamp, msg_to_process->timestamp)){
 							LPS[lid_receiver]->bound = list_prev(LPS[lid_receiver]->bound);
 						}
 
 						LPS[lid_receiver]->state = LP_STATE_ROLLBACK;
-              printf("%llu - Process %d set to STATE_ROLLBACK due to msg from %d at time %f type %d (straggler)\n", CLOCK_READ(), lid_receiver, msg_to_process->sender, msg_to_process->timestamp, msg_to_process->type);
-              fflush(stdout);
-
 					}
 
 					break;

--- a/src/scheduler/binding.c
+++ b/src/scheduler/binding.c
@@ -60,13 +60,17 @@ static __thread bool first_lp_binding = true;
  */
 __thread LP_state **LPS_bound = NULL;
 
-static int binding_acquire_phase = 0;
-static __thread int local_binding_acquire_phase = 0;
 
 static unsigned int *new_LPS_binding;
 static timer rebinding_timer;
+
+#ifdef HAVE_LP_REBINDING
+static int binding_acquire_phase = 0;
+static __thread int local_binding_acquire_phase = 0;
+
 static int binding_phase = 0;
 static __thread int local_binding_phase = 0;
+#endif
 
 static atomic_t worker_thread_reduction;
 
@@ -196,6 +200,7 @@ static inline void LP_knapsack(void) {
 	}
 }
 
+#ifdef HAVE_LP_REBINDING
 
 static void post_local_reduction(void) {
 	unsigned int i;
@@ -233,6 +238,7 @@ static void install_binding(void) {
 	}
 }
 
+#endif
 
 
 /**

--- a/src/scheduler/scheduler.c
+++ b/src/scheduler/scheduler.c
@@ -396,18 +396,14 @@ void activate_LP(unsigned int lp, simtime_t lvt, void *evt, void *state) {
 //		enable_preemption();
 //	#endif
 
-  //	printf(" LP %d current_evt->timestap:%f\n",lp,current_evt->timestamp);
 	#ifdef HAVE_CROSS_STATE
 	// Activate memory view for the current LP
 	lp_alloc_schedule();
 	#endif
 
-	//printf("Schedule %d\n",lp);
-	//printf("LP[%d] state: %lu\n",lp,LPS[lp]->state);
 	if(is_blocked_state(LPS[lp]->state)){
-		printf("lp %u in state %u wait_on_rendezvous:%llu tid:%d wait_object:%d \n ",lp,LPS[lp]->state,LPS[lp]->wait_on_rendezvous,tid,LPS[lp]->wait_on_object);
 		rootsim_error(true, "Critical condition: LP[%d] has a wrong state -> %d. Aborting...\n", lp,LPS[lp]->state);
-  }
+	}
 
 	#ifdef ENABLE_ULT
 	context_switch(&kernel_context, &LPS[lp]->context);
@@ -438,7 +434,7 @@ void activate_LP(unsigned int lp, simtime_t lvt, void *evt, void *state) {
 
 
 bool check_rendevouz_request(unsigned int lid){
-	msg_t *temp_mess;;
+	msg_t *temp_mess;
 
 	if(LPS[lid]->state != LP_STATE_WAIT_FOR_SYNCH)
 		return false;
@@ -447,7 +443,6 @@ bool check_rendevouz_request(unsigned int lid){
 
 	if(LPS[lid]->bound != NULL && list_next(LPS[lid]->bound) != NULL){
 		temp_mess = list_next(LPS[lid]->bound);
-		//printf("\t \t Randezvous_mark: %llu LPS[%d]->wait_on_rendezvous:%llu\n",temp_mess->rendezvous_mark, lid,LPS[lid]->wait_on_rendezvous);
 		return temp_mess->type == RENDEZVOUS_START && LPS[lid]->wait_on_rendezvous > temp_mess->rendezvous_mark;
 	}
 
@@ -482,28 +477,27 @@ void schedule(void) {
 			lid = smallest_timestamp_first();
 	}
 
-  // No logical process found with events to be processed
+	// No logical process found with events to be processed
 	if (lid == IDLE_PROCESS) {
-      statistics_post_lp_data(lid, STAT_IDLE_CYCLES, 1.0);
-      return;
-    	}
+		statistics_post_lp_data(lid, STAT_IDLE_CYCLES, 1.0);
+		return;
+	}
 
 
 	// If we have to rollback
-  if(LPS[lid]->state == LP_STATE_ROLLBACK) {
-    rollback(lid);
-    LPS[lid]->state = LP_STATE_READY;
-    send_outgoing_msgs(lid);
+	if(LPS[lid]->state == LP_STATE_ROLLBACK) {
+		rollback(lid);
+		LPS[lid]->state = LP_STATE_READY;
+		send_outgoing_msgs(lid);
+		return;
+	}
 
-    return;
-  }
-
-  if(!is_blocked_state(LPS[lid]->state) && LPS[lid]->state != LP_STATE_READY_FOR_SYNCH){
-    event = advance_to_next_event(lid);
-  }
-  else {
-    event = LPS[lid]->bound;
-  }
+	if(!is_blocked_state(LPS[lid]->state) && LPS[lid]->state != LP_STATE_READY_FOR_SYNCH){
+		event = advance_to_next_event(lid);
+	}
+	else {
+		event = LPS[lid]->bound;
+	}
 
 
 	// Sanity check: if we get here, it means that lid is a LP which has
@@ -520,41 +514,36 @@ void schedule(void) {
 
 	state = LPS[lid]->current_base_pointer;
 
-	#ifdef HAVE_CROSS_STATE
 
+#ifdef HAVE_CROSS_STATE
 	// In case we are resuming an interrupted execution, we keep track of this.
-	// If at the end of the scheduling the LP is not blocked, we can unblokc all the remote objects
-	//if(LPS[lid]->state == LP_STATE_READY_FOR_SYNCH) {
-	if(is_blocked_state(LPS[lid]->state)) { // == LP_STATE_READY_FOR_SYNCH) {
-    resume_execution = true;
+	// If at the end of the scheduling the LP is not blocked, we can unblock all the remote objects
+	if(is_blocked_state(LPS[lid]->state)) {
+		resume_execution = true;
 	}
-	#endif
+#endif
+
 
 	// Schedule the LP user-level thread
 	LPS[lid]->state = LP_STATE_RUNNING;
-  printf("LP %d about to run event type %d at %f mark %d rm %d\n", lid, event->type, lvt(lid), event->mark, event->rendezvous_mark);
-  activate_LP(lid, lvt(lid), event, state);
+	activate_LP(lid, lvt(lid), event, state);
 
-  //printf("LP[%d] state %d: ",lid, LPS[lid]->state);
 	if(!is_blocked_state(LPS[lid]->state)) {
 		LPS[lid]->state = LP_STATE_READY;
 		send_outgoing_msgs(lid);
 	}
 
 
-	#ifdef HAVE_CROSS_STATE
+#ifdef HAVE_CROSS_STATE
 	if(resume_execution && !is_blocked_state(LPS[lid]->state)) {
 		unblock_synchronized_objects(lid);
 
 		// This is to avoid domino effect when relying on rendezvous messages
 		force_LP_checkpoint(lid);
 	}
-	#endif
+#endif
 
 
 	// Log the state, if needed
 	LogState(lid);
-
-
 }
-


### PR DESCRIPTION
The first commit aimed to fix the missing headers inclusion on the ECS branch.

The `ECS reworking` `3c7c8f4c41f89bb2e97c32a294b05c0d2ae136e2` commit have introduced a lot of mis-indented lines, comments and prints that were cleaned up in the second commit.

The others are minor fixes that helped to cleane up the gcc output.