### PR TITLE
bugfix: wrong msgchannel reallocation size

### DIFF
--- a/src/datatypes/msgchannel.c
+++ b/src/datatypes/msgchannel.c
@@ -97,7 +97,7 @@ void insert_msg(msg_channel *mc, msg_t *msg) {
 		spin_lock(&mc->read_lock);
 
 		mc->buffers[M_WRITE]->size *= 2;
-		mc->buffers[M_WRITE]->buffer = rsrealloc((void *)mc->buffers[M_WRITE]->buffer, mc->buffers[M_WRITE]->size);
+		mc->buffers[M_WRITE]->buffer = rsrealloc((void *)mc->buffers[M_WRITE]->buffer, mc->buffers[M_WRITE]->size * sizeof(msg_t *));
 
 		if(mc->buffers[M_WRITE]->buffer == NULL)
 			rootsim_error(true, "%s:%d: Unable to reallocate message channel\n", __FILE__, __LINE__);

--- a/src/datatypes/msgchannel.h
+++ b/src/datatypes/msgchannel.h
@@ -42,7 +42,7 @@ typedef struct _msg_channel {
 	spinlock_t		write_lock;
 } msg_channel;
 
-#define INITIAL_CHANNEL_SIZE (512 * sizeof(msg_t *))
+#define INITIAL_CHANNEL_SIZE (512)
 
 extern msg_channel *init_channel(void);
 extern void fini_channel(msg_channel *);


### PR DESCRIPTION
The message channel reallocation call was wrongly calculating the new
size ( missing `* sizeof()` )