### PR TITLE
Merge latest bugfixes into develop

### DIFF
--- a/src/datatypes/msgchannel.c
+++ b/src/datatypes/msgchannel.c
@@ -97,7 +97,7 @@ void insert_msg(msg_channel *mc, msg_t *msg) {
 		spin_lock(&mc->read_lock);
 
 		mc->buffers[M_WRITE]->size *= 2;
-		mc->buffers[M_WRITE]->buffer = rsrealloc((void *)mc->buffers[M_WRITE]->buffer, mc->buffers[M_WRITE]->size);
+		mc->buffers[M_WRITE]->buffer = rsrealloc((void *)mc->buffers[M_WRITE]->buffer, mc->buffers[M_WRITE]->size * sizeof(msg_t *));
 
 		if(mc->buffers[M_WRITE]->buffer == NULL)
 			rootsim_error(true, "%s:%d: Unable to reallocate message channel\n", __FILE__, __LINE__);

--- a/src/datatypes/msgchannel.h
+++ b/src/datatypes/msgchannel.h
@@ -42,7 +42,7 @@ typedef struct _msg_channel {
 	spinlock_t		write_lock;
 } msg_channel;
 
-#define INITIAL_CHANNEL_SIZE (512 * sizeof(msg_t *))
+#define INITIAL_CHANNEL_SIZE (512)
 
 extern msg_channel *init_channel(void);
 extern void fini_channel(msg_channel *);

--- a/src/lib/topology.c
+++ b/src/lib/topology.c
@@ -25,11 +25,6 @@ unsigned int FindReceiver(int topology) {
 
 	if(first_call) {
 		edge = sqrt(n_prc_tot);
-		// Sanity check!
-		if(edge * edge != n_prc_tot) {
-			rootsim_error(true, "Hexagonal map wrongly specified!\n");
-			return 0;
-		}
 		first_call = false;
 	}
 
@@ -43,6 +38,11 @@ unsigned int FindReceiver(int topology) {
 	switch(topology) {
 
 		case TOPOLOGY_HEXAGON:
+			// Sanity check!
+			if(edge * edge != n_prc_tot) {
+				rootsim_error(true, "Hexagonal map wrongly specified!\n");
+				return 0;
+			}
 
 			// Convert linear coords to hexagonal coords
 			x = gid_to_int(sender) % edge;
@@ -93,6 +93,11 @@ unsigned int FindReceiver(int topology) {
 
 
 		case TOPOLOGY_SQUARE:
+			// Sanity check!
+			if(edge * edge != n_prc_tot) {
+				rootsim_error(true, "Hexagonal map wrongly specified!\n");
+				return 0;
+			}
 
 			// Convert linear coords to square coords
 			x = gid_to_int(sender) % edge;
@@ -136,6 +141,11 @@ unsigned int FindReceiver(int topology) {
 			break;
 
 		case TOPOLOGY_TORUS:
+			// Sanity check!
+			if(edge * edge != n_prc_tot) {
+				rootsim_error(true, "Hexagonal map wrongly specified!\n");
+				return 0;
+			}
 
 			// Convert linear coords to square coords
 			x = gid_to_int(sender) % edge;

--- a/src/statistics/statistics.c
+++ b/src/statistics/statistics.c
@@ -688,13 +688,6 @@ void statistics_fini(void) {
 void statistics_post_lp_data(LID_t the_lid, unsigned int type, double data) {
 	unsigned int lid = lid_to_int(the_lid);
 
-	// Sanity check
-	#ifndef NDEBUG
-	if(!is_valid_lid(the_lid)) {
-		rootsim_error(true, "%s:%d: Using an invalid lid to post statistics", __FILE__, __LINE__);
-	}
-	#endif
-
 	if(rootsim_config.serial) {
 
 		switch(type) {


### PR DESCRIPTION
This PR includes into `develop` the latest bugfixes to `release-2.0.0`:

* A fix on the topology library: there are some topologies which do not require
 to have a square number of LPs. This check was anyhow made for all topologies.
* Problem with the validation of `idle_process`: it is associated with a non-existing
 id. The current implementation of the statistics subsystem uses this LID to access
 statistics at the scope of the platform. Yet a sanity check on the passed LID was
 preventing this portion of the statistics to function properly.
* Memory reallocation in `msgchannel`: when converting from buffers to pointers,
 the size of the msgchannel was passed from bytes to number of `msg_t *` in the
 array. Everywhere except for the case of a `realloc`. Therefore, upon a `realloc`,
 invalid memory was accessed, causing undefined behaviour.