### PR TITLE
bugfix: list_insert_tail do not set prev & next to null

### DIFF
--- a/src/datatypes/list.h
+++ b/src/datatypes/list.h
@@ -111,6 +111,8 @@ typedef struct rootsim_list {
 		__typeof__(data) __new_n = (data); /* in-block scope variable */\
 		size_t __size_before;\
 		rootsim_list *__l;\
+		__new_n->next = NULL;\
+		__new_n->prev = NULL;\
 		do {\
 			__l = (rootsim_list *)(li);\
 			assert(__l);\


### PR DESCRIPTION
The messages exchange subsystem for inter-kernel communication was broken by a flaw of list datatype. The `list_insert_tail()` macro was not setting to NULL the prev and next pointers of the new node. 