### PR TITLE
MPI: Get rid of MPI Datatype

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -143,6 +143,9 @@ typedef enum {positive, negative, control} message_kind_t;
 typedef unsigned char phase_colour;
 #endif
 
+#define MSG_PADDING offsetof(msg_t, sender)
+#define MSG_META_SIZE (sizeof(msg_t) - MSG_PADDING)
+
 /** The MPI datatype msg_mpi_t depends on the order of this struct.
    See src/communication/mpi.c for the implementation of the datatype */
 /// Message Type definition


### PR DESCRIPTION
The use of MPI datatype has been dropped. Messages between kernels are now exchanged as simple byte stream.
This allows to have the possibility to send variable length messages
while keeping the code really simple.

The synchronous `MPI_Send` has been removed in favor of the `MPI_Get_Count`
approach