### PR TITLE
Performance of slab memory management

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,8 +25,9 @@ librootsim_a_SOURCES =	main.c \
 			arch/linux/jmp.S \
 			datatypes/array.c \
 			datatypes/calqueue.c \
-			datatypes/slab.c \
 			datatypes/msgchannel.c \
+			datatypes/slab.c \
+			datatypes/treiber.c \
 			mm/state.c \
 			mm/ecs.c \
 			mm/ecs_callback.S \

--- a/src/communication/communication.c
+++ b/src/communication/communication.c
@@ -144,11 +144,15 @@ msg_t *get_msg_from_slab(void) {
 }
 
 void msg_release(msg_t *msg) {
+	int thr;
+
 	if(sizeof(msg_t) + msg->size <= SLAB_MSG_SIZE) {
-		int thr = msg->alloc_tid;
-		msg->prev = 0xBAADBAAD;
-		msg->next = 0xBAADBAAD;
-		treiber_push(msg_treiber[thr], msg);
+		thr = msg->alloc_tid;
+		if(local_tid == thr) {
+			slab_free(&msg_slab[thr], msg);
+		} else {
+			treiber_push(msg_treiber[thr], msg);
+		}
 	} else {
 		rsfree(msg);
 	}

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -156,7 +156,7 @@ typedef struct _msg_t {
 	// Pointers to attach messages to chains
 	struct _msg_t 		*next;
 	struct _msg_t 		*prev;
-	int			alloc_tid; // TODO: this should be moved into an external container, to avoid transmitting it!
+	unsigned int		alloc_tid; // TODO: this should be moved into an external container, to avoid transmitting it!
 
 	/* Place here all members which must be transmitted over the network. It is convenient not to reorder the members
 	 * of the structure. If new members have to be addedd, place them right before the "Model data" part.
@@ -192,7 +192,7 @@ typedef struct _msg_hdr_t {
 	// TODO: non serve davvero, togliere
 	int   			type;
 	unsigned long long	rendezvous_mark;	/// Unique identifier of the message, used for rendez-vous event
-	int			alloc_tid;
+	unsigned int		alloc_tid;
 	// TODO: fine togliere
 	simtime_t		timestamp;
 	simtime_t		send_time;

--- a/src/datatypes/treiber.c
+++ b/src/datatypes/treiber.c
@@ -1,0 +1,73 @@
+/**
+*			Copyright (C) 2008-2018 HPDCS Group
+*			http://www.dis.uniroma1.it/~hpdcs
+*
+*
+* This file is part of ROOT-Sim (ROme OpTimistic Simulator).
+*
+* ROOT-Sim is free software; you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation; only version 3 of the License applies.
+*
+* ROOT-Sim is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* ROOT-Sim; if not, write to the Free Software Foundation, Inc.,
+* 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*
+* @file triber.c
+* @brief This module implements a Triber stack.
+*/
+
+#include <datatypes/treiber.h>
+#include <mm/dymelor.h>
+
+// TODO: move the CAS implementation with the builtin in <arch/atomic.h>
+
+#define CAS(ptr, old, new) __sync_bool_compare_and_swap((ptr), (old), (new))
+
+treiber *treiber_init(void) {
+	treiber *ret;
+
+	ret = rsalloc(sizeof(treiber));
+	ret->next = NULL;
+	ret->data = NULL;
+
+	return ret;
+}
+
+
+void treiber_push(treiber *treib, void *data) {
+	treiber *f;
+	treiber *t = rsalloc(sizeof(treiber));
+	t->data = data;
+
+	do {
+		f = treib->next;
+		t->next = f;
+		if(CAS(&treib->next, f, t))
+			return;
+	} while(1);
+}
+
+void *treiber_pop(treiber *treib) {
+	void *data;
+
+	if(treib->next == NULL) {
+		return NULL;
+	}
+
+	do {
+		treiber *f = treib->next;
+		treiber *f_nxt = treib->next->next;
+
+		if(CAS(&treib->next, f, f_nxt)) {
+			data = f->data;
+			rsfree(f);
+			return data;
+		}
+	} while(1);
+}
+

--- a/src/datatypes/treiber.c
+++ b/src/datatypes/treiber.c
@@ -71,3 +71,8 @@ void *treiber_pop(treiber *treib) {
 	} while(1);
 }
 
+void *treiber_detach(treiber *treib) {
+	treiber *f;
+	f = __sync_lock_test_and_set(&treib->next, NULL);
+	return f;
+}

--- a/src/datatypes/treiber.h
+++ b/src/datatypes/treiber.h
@@ -1,0 +1,34 @@
+/**
+*			Copyright (C) 2008-2018 HPDCS Group
+*			http://www.dis.uniroma1.it/~hpdcs
+*
+*
+* This file is part of ROOT-Sim (ROme OpTimistic Simulator).
+*
+* ROOT-Sim is free software; you can redistribute it and/or modify it under the
+* terms of the GNU General Public License as published by the Free Software
+* Foundation; only version 3 of the License applies.
+*
+* ROOT-Sim is distributed in the hope that it will be useful, but WITHOUT ANY
+* WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+* A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License along with
+* ROOT-Sim; if not, write to the Free Software Foundation, Inc.,
+* 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*
+* @file triber.h
+* @brief This module implements a Triber stack.
+*/
+
+#pragma once
+
+typedef struct _treiber {
+	struct _treiber *next;
+	void *data;
+} treiber;
+
+extern treiber *treiber_init(void);
+extern void treiber_push(treiber *, void *);
+extern void *treiber_pop(treiber *);
+

--- a/src/datatypes/treiber.h
+++ b/src/datatypes/treiber.h
@@ -31,4 +31,5 @@ typedef struct _treiber {
 extern treiber *treiber_init(void);
 extern void treiber_push(treiber *, void *);
 extern void *treiber_pop(treiber *);
+extern void *treiber_detach(treiber *);
 


### PR DESCRIPTION
This commit introduces a non-blocking retirement queue for buffers
obtained by the slab allocators, which allows to reduce concurrency
across threads when releasing memory.

This is still suboptimal. We should implement as well a backoff array in
case CAS'es start to fail too much.

Signed-off-by: Alessandro Pellegrini <pellegrini@dis.uniroma1.it>