### PR TITLE
Transition from (M,N) to (M,1) msg channel

### DIFF
--- a/src/datatypes/msgchannel.c
+++ b/src/datatypes/msgchannel.c
@@ -17,8 +17,8 @@
 * ROOT-Sim; if not, write to the Free Software Foundation, Inc.,
 * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 *
-* @file bh.c
-* @brief
+* @file msgchannel.c
+* @brief This module implements an (M, 1) channel to transfer message pointers.
 * @author Francesco Quaglia
 */
 
@@ -80,7 +80,6 @@ msg_channel *init_channel(void) {
 	if(mc->buffers[M_READ]->buffer == NULL || mc->buffers[M_WRITE]->buffer == NULL)
 		rootsim_error(true, "%s:%d: Unable to allocate message channel\n", __FILE__, __LINE__);
 
-	spinlock_init(&mc->read_lock);
 	spinlock_init(&mc->write_lock);
 
         return mc;
@@ -94,7 +93,6 @@ void insert_msg(msg_channel *mc, msg_t *msg) {
 	// Reallocate the live BH buffer. Don't touch the other buffer,
 	// as in this way the critical section is much shorter
 	if(mc->buffers[M_WRITE]->written == mc->buffers[M_WRITE]->size) {
-		spin_lock(&mc->read_lock);
 
 		mc->buffers[M_WRITE]->size *= 2;
 		mc->buffers[M_WRITE]->buffer = rsrealloc((void *)mc->buffers[M_WRITE]->buffer, mc->buffers[M_WRITE]->size * sizeof(msg_t *));
@@ -102,7 +100,6 @@ void insert_msg(msg_channel *mc, msg_t *msg) {
 		if(mc->buffers[M_WRITE]->buffer == NULL)
 			rootsim_error(true, "%s:%d: Unable to reallocate message channel\n", __FILE__, __LINE__);
 
-		spin_unlock(&mc->read_lock);
 	}
 
 	#ifndef NDEBUG
@@ -117,8 +114,6 @@ void insert_msg(msg_channel *mc, msg_t *msg) {
 
 void *get_msg(msg_channel *mc) {
 	msg_t *msg = NULL;
-
-	spin_lock(&mc->read_lock);
 
 	if(mc->buffers[M_READ]->read == mc->buffers[M_READ]->written) {
 		spin_lock(&mc->write_lock);
@@ -140,7 +135,6 @@ void *get_msg(msg_channel *mc) {
 	#endif
 
     leave:
-	spin_unlock(&mc->read_lock);
 	return msg;
 }
 

--- a/src/datatypes/msgchannel.h
+++ b/src/datatypes/msgchannel.h
@@ -18,7 +18,7 @@
 * 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 *
 * @file msgchannel.h
-* @brief This module implements an (M, N) channel to transfer message pointers.
+* @brief This module implements an (M, 1) channel to transfer message pointers.
 * @author Francesco Quaglia
 * @author Alessandro Pellegrini
 */
@@ -39,7 +39,6 @@ struct _msg_buff {
 typedef struct _msg_channel {
 	struct _msg_buff	*volatile buffers[2];
 	atomic_t		size;
-	spinlock_t		read_lock;
 	spinlock_t		write_lock;
 } msg_channel;
 


### PR DESCRIPTION
This commit makes the message channel data structure (M,1).

This change has a twofold effect:
* One of the two locks has been removed, with a slight performance
  improvement;
* A possible deadlock condition (although this never materialized) has
  been resolved, due to the fact that the lock acquisition was not
  respecting 2PL.

Signed-off-by: Alessandro Pellegrini <pellegrini@dis.uniroma1.it>