### PR TITLE
Fixed tid type mismatch

### DIFF
--- a/src/communication/communication.c
+++ b/src/communication/communication.c
@@ -145,7 +145,7 @@ msg_t *get_msg_from_slab(void) {
 }
 
 void msg_release(msg_t *msg) {
-	int thr;
+	unsigned int thr;
 
 	if(sizeof(msg_t) + msg->size <= SLAB_MSG_SIZE) {
 		thr = msg->alloc_tid;


### PR DESCRIPTION
Simple fix: gcc `sign-compare` worning.