### PR TITLE
Refactor log size

### DIFF
--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -88,7 +88,7 @@ void *log_full(struct lp_struct *lp)
 
 	m_state = lp->mm->m_state;
 	m_state->is_incremental = false;
-	size = get_log_size(lp->mm->m_state);
+	size = get_log_size(m_state);
 
 	ckpt = rsalloc(size);
 
@@ -155,7 +155,7 @@ void *log_full(struct lp_struct *lp)
 		// Reset Dirty Bitmap, as there is a full ckpt in the chain now
 		m_area->dirty_chunks = 0;
 		m_area->state_changed = 0;
-		bzero((void *)m_area->dirty_bitmap, bitmap_size);
+		bzero(m_area->dirty_bitmap, bitmap_size);
 
 	}			// For each malloc area
 
@@ -235,7 +235,7 @@ void restore_full(struct lp_struct *lp, void *ckpt)
 	timer_start(recovery_timer);
 	ptr = ckpt;
 	m_state = lp->mm->m_state;
-	target_ptr = ptr + m_state->total_log_size;
+	target_ptr = ptr + ((malloc_state *) ptr)->total_log_size;
 	original_num_areas = m_state->num_areas;
 
 	// restore the old malloc state except for the malloc areas array

--- a/src/mm/checkpoints.c
+++ b/src/mm/checkpoints.c
@@ -80,12 +80,14 @@ void *log_full(struct lp_struct *lp)
 	int i;
 	size_t size, chunk_size, bitmap_size;
 	malloc_area *m_area;
+	malloc_state *m_state;
 
 	// Timers for self-tuning of the simulation platform
 	timer checkpoint_timer;
 	timer_start(checkpoint_timer);
 
-	lp->mm->m_state->is_incremental = false;
+	m_state = lp->mm->m_state;
+	m_state->is_incremental = false;
 	size = get_log_size(lp->mm->m_state);
 
 	ckpt = rsalloc(size);
@@ -97,13 +99,13 @@ void *log_full(struct lp_struct *lp)
 	ptr = ckpt;
 
 	// Copy malloc_state in the ckpt
-	memcpy(ptr, lp->mm->m_state, sizeof(malloc_state));
+	memcpy(ptr, m_state, sizeof(malloc_state));
 	ptr = (void *)((char *)ptr + sizeof(malloc_state));
 	((malloc_state *) ckpt)->timestamp = lvt(lp);
 
-	for (i = 0; i < lp->mm->m_state->num_areas; i++) {
+	for (i = 0; i < m_state->num_areas; i++) {
 
-		m_area = &lp->mm->m_state->areas[i];
+		m_area = &m_state->areas[i];
 
 		// Copy the bitmap
 
@@ -163,9 +165,7 @@ void *log_full(struct lp_struct *lp)
 			      (char *)ckpt + size - (char *)ptr, lp->lid.to_int,
 			      ckpt, size, size, ptr, (char *)ckpt + size);
 
-	lp->mm->m_state->dirty_areas = 0;
-	lp->mm->m_state->dirty_bitmap_size = 0;
-	lp->mm->m_state->total_inc_size = 0;
+	m_state->total_inc_size = sizeof(malloc_state);
 
 	statistics_post_data(lp, STAT_CKPT_TIME, (double)timer_value_micro(checkpoint_timer));
 	statistics_post_data(lp, STAT_CKPT_MEM, (double)size);
@@ -224,33 +224,34 @@ void *log_state(struct lp_struct *lp)
 */
 void restore_full(struct lp_struct *lp, void *ckpt)
 {
-	void *ptr;
-	int i, original_num_areas, restored_areas;
+	char *ptr, *target_ptr;
+	int i, original_num_areas;
 	size_t chunk_size, bitmap_size;
-	malloc_area *m_area, *new_area;
+	malloc_area *m_area;
+	malloc_state *m_state;
 
 	// Timers for simulation platform self-tuning
 	timer recovery_timer;
 	timer_start(recovery_timer);
-	restored_areas = 0;
 	ptr = ckpt;
-	original_num_areas = lp->mm->m_state->num_areas;
-	new_area = lp->mm->m_state->areas;
+	m_state = lp->mm->m_state;
+	target_ptr = ptr + m_state->total_log_size;
+	original_num_areas = m_state->num_areas;
 
-	// Restore malloc_state
-	memcpy(lp->mm->m_state, ptr, sizeof(malloc_state));
-	ptr = (void *)((char *)ptr + sizeof(malloc_state));
-
-	lp->mm->m_state->areas = new_area;
+	// restore the old malloc state except for the malloc areas array
+	m_area = m_state->areas;
+	memcpy(m_state, ptr, sizeof(malloc_state));
+	m_state->areas = m_area;
+	ptr += sizeof(malloc_state);
 
 	// Scan areas and chunk to restore them
-	for (i = 0; i < lp->mm->m_state->num_areas; i++) {
+	for (i = 0; i < m_state->num_areas; i++) {
 
-		m_area = &lp->mm->m_state->areas[i];
+		m_area = &m_state->areas[i];
 
 		bitmap_size = bitmap_required_size(m_area->num_chunks);
 
-		if (restored_areas == lp->mm->m_state->busy_areas || m_area->idx != ((malloc_area *) ptr)->idx) {
+		if (ptr >= target_ptr || m_area->idx != ((malloc_area *) ptr)->idx) {
 
 			m_area->dirty_chunks = 0;
 			m_area->state_changed = 0;
@@ -263,19 +264,17 @@ void restore_full(struct lp_struct *lp, void *ckpt)
 				memset(m_area->use_bitmap, 0, bitmap_size);
 				memset(m_area->dirty_bitmap, 0, bitmap_size);
 			}
-			m_area->last_access = lp->mm->m_state->timestamp;
+			m_area->last_access = m_state->timestamp;
 
 			continue;
 		}
 		// Restore the malloc_area
 		memcpy(m_area, ptr, sizeof(malloc_area));
-		ptr = (void *)((char *)ptr + sizeof(malloc_area));
-
-		restored_areas++;
+		ptr += sizeof(malloc_area);
 
 		// Restore use bitmap
 		memcpy(m_area->use_bitmap, ptr, bitmap_size);
-		ptr = (void *)((char *)ptr + bitmap_size);
+		ptr += bitmap_size;
 
 		// Reset dirty bitmap
 		bzero(m_area->dirty_bitmap, bitmap_size);
@@ -288,7 +287,7 @@ void restore_full(struct lp_struct *lp, void *ckpt)
 		if (CHECK_LOG_MODE_BIT(m_area)) {
 			// The area has been entirely logged
 			memcpy(m_area->area, ptr, m_area->num_chunks * chunk_size);
-			ptr = (void *)((char *)ptr + m_area->num_chunks * chunk_size);
+			ptr += m_area->num_chunks * chunk_size;
 
 		} else {
 			// The area was partially logged.
@@ -297,7 +296,7 @@ void restore_full(struct lp_struct *lp, void *ckpt)
 
 #define copy_to_area(x) ({\
 		memcpy((void*)((char*)m_area->area + ((x) * chunk_size)), ptr, chunk_size);\
-		ptr = (void*)((char*)ptr + chunk_size);})
+		ptr += chunk_size;})
 
 			bitmap_foreach_set(m_area->use_bitmap, bitmap_size, copy_to_area);
 
@@ -307,17 +306,17 @@ void restore_full(struct lp_struct *lp, void *ckpt)
 	}
 
 	// Check whether there are more allocated areas which are not present in the log
-	if (original_num_areas > lp->mm->m_state->num_areas) {
+	if (original_num_areas > m_state->num_areas) {
 
-		for (i = lp->mm->m_state->num_areas; i < original_num_areas; i++) {
+		for (i = m_state->num_areas; i < original_num_areas; i++) {
 
-			m_area = &lp->mm->m_state->areas[i];
+			m_area = &m_state->areas[i];
 			m_area->alloc_chunks = 0;
 			m_area->dirty_chunks = 0;
 			m_area->state_changed = 0;
 			m_area->next_chunk = 0;
-			m_area->last_access = lp->mm->m_state->timestamp;
-			lp->mm->m_state->areas[m_area->prev].next = m_area->idx;
+			m_area->last_access = m_state->timestamp;
+			m_state->areas[m_area->prev].next = m_area->idx;
 
 			RESET_LOG_MODE_BIT(m_area);
 			RESET_AREA_LOCK_BIT(m_area);
@@ -329,14 +328,12 @@ void restore_full(struct lp_struct *lp, void *ckpt)
 				memset(m_area->dirty_bitmap, 0, bitmap_size);
 			}
 		}
-		lp->mm->m_state->num_areas = original_num_areas;
+		m_state->num_areas = original_num_areas;
 	}
 
-	lp->mm->m_state->timestamp = -1;
-	lp->mm->m_state->is_incremental = false;
-	lp->mm->m_state->dirty_areas = 0;
-	lp->mm->m_state->dirty_bitmap_size = 0;
-	lp->mm->m_state->total_inc_size = 0;
+	m_state->timestamp = -1;
+	m_state->is_incremental = false;
+	m_state->total_inc_size = sizeof(malloc_state);
 
 	statistics_post_data(lp, STAT_RECOVERY_TIME, (double)timer_value_micro(recovery_timer));
 }

--- a/src/mm/dymelor.c
+++ b/src/mm/dymelor.c
@@ -323,7 +323,7 @@ void *do_malloc(struct lp_struct *lp, size_t size)
 	if (!CHECK_LOG_MODE_BIT(m_area)) {
 		if ((double)m_area->alloc_chunks / (double)m_area->num_chunks > MAX_LOG_THRESHOLD) {
 			SET_LOG_MODE_BIT(m_area);
-			m_state->total_log_size += (m_area->num_chunks - (m_area->alloc_chunks - 1)) * size;
+			m_state->total_log_size += (m_area->num_chunks - m_area->alloc_chunks) * size;
 		} else
 			m_state->total_log_size += size;
 	}

--- a/src/mm/dymelor.h
+++ b/src/mm/dymelor.h
@@ -47,9 +47,8 @@
 
 //ADDED BY MAT 0x00000200000000000
 #define LP_PREALLOCATION_INITIAL_ADDRESS	(void *)0x0000008000000000
-#define MASK 0x00000001		// Mask used to check, set and unset bits
 
-#define MIN_CHUNK_SIZE 128	// Size (in bytes) of the smallest chunk provideable by DyMeLoR
+#define MIN_CHUNK_SIZE 128U	// Size (in bytes) of the smallest chunk provideable by DyMeLoR
 #define MAX_CHUNK_SIZE 4194304	// Size (in bytes) of the biggest one. Notice that if this number
 				// is too large, performance (and memory usage) might be affected.
 				// If it is too small, large amount of memory requests by the
@@ -79,15 +78,15 @@
 #define GET_CACHE_LINE_NUMBER(P) ((unsigned long)((P >> 4) & (CACHE_SIZE - 1)))
 
 // Macros uset to check, set and unset special purpose bits
-#define SET_LOG_MODE_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size |=  (MASK << 0))
-#define RESET_LOG_MODE_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size &= ~(MASK << 0))
-#define CHECK_LOG_MODE_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size &   (MASK << 0))
+#define SET_LOG_MODE_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size |=  (1UL << 0))
+#define RESET_LOG_MODE_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size &= ~(1UL << 0))
+#define CHECK_LOG_MODE_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size &   (1UL << 0))
 
-#define SET_AREA_LOCK_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size |=  (MASK << 1))
-#define RESET_AREA_LOCK_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size &= ~(MASK << 1))
-#define CHECK_AREA_LOCK_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size &   (MASK << 1))
+#define SET_AREA_LOCK_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size |=  (1UL << 1))
+#define RESET_AREA_LOCK_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size &= ~(1UL << 1))
+#define CHECK_AREA_LOCK_BIT(m_area)	(((malloc_area*)(m_area))->chunk_size &   (1UL << 1))
 
-#define UNTAGGED_CHUNK_SIZE(m_area)	(((malloc_area*)(m_area))->chunk_size & ~((MASK << 0) | (MASK << 1)))
+#define UNTAGGED_CHUNK_SIZE(m_area)	(((malloc_area*)(m_area))->chunk_size & ~((1UL << 0) | (1UL << 1)))
 
 #define POWEROF2(x) (1UL << (1 + (63 - __builtin_clzl((x) - 1))))
 #define IS_POWEROF2(x) ((x) != 0 && ((x) & ((x) - 1)) == 0)
@@ -122,12 +121,8 @@ struct _malloc_state {
 	bool is_incremental;	///< Tells if it is an incremental log or a full one (when used for logging)
 	size_t total_log_size;
 	size_t total_inc_size;
-	size_t bitmap_size;
-	size_t dirty_bitmap_size;
 	int num_areas;
 	int max_num_areas;
-	int busy_areas;
-	int dirty_areas;
 	simtime_t timestamp;
 	struct _malloc_area *areas;
 };


### PR DESCRIPTION
A little DyMeLoR refactor:
- removed redundant members from the malloc_state used to compute snapshot sizes
- removed a useless fflush from DyMeLoR's malloc
- removed useless floating point operations in DyMeLoR's malloc
- fixed an old off-by-one bug in the mechanism used to log full malloc_areas
- incremented a bit code readability
