### PR TITLE
Force push for gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ deploy:
  - provider: pages
    skip-cleanup: true
    github-token: $DOCS_SECRET
-   keep-history: true
+   keep-history: false
    local-dir: ROOT-Sim
    verbose: true
    on:
@@ -63,7 +63,7 @@ deploy:
  - provider: pages
    skip-cleanup: true
    github-token: $DOCS_SECRET
-   keep-history: true
+   keep-history: false
    local-dir: ROOT-Sim
    verbose: true
    on:


### PR DESCRIPTION
The largest part of the repo size was related to the gh-pages branch,
and all the images generated by doxygen in there.

I have now squashed all heavyweight repos. This quick patch instructs
Travis to force push once the new website is deployed on gh-pages.

Signed-off-by: Alessandro Pellegrini <pellegrini@dis.uniroma1.it>