### PR TITLE
Better management of posix_memalign error

### DIFF
--- a/src/mm/slab.c
+++ b/src/mm/slab.c
@@ -34,6 +34,7 @@
 #include <sys/mman.h>
 #include <math.h>
 #include <assert.h>
+#include <string.h>
 
 #include <core/core.h>
 #include <mm/dymelor.h>
@@ -211,9 +212,11 @@ void *slab_alloc(struct slab_chain *const sch)
 			}
 		} else {
 			const int err = posix_memalign((void **)&sch->partial, sch->slabsize, sch->pages_per_alloc);
+			char err_str[512];
 
 			if (unlikely(err != 0)) {
-				fprintf(stderr, "posix_memalign(align=%zu, size=%zu): %d\n", sch->slabsize, sch->pages_per_alloc, err);
+				strerror_r(err, err_str, 512);
+				fprintf(stderr, "posix_memalign(align=%zu, size=%zu): %s\n", sch->slabsize, sch->pages_per_alloc, err_str);
 
 				ret = sch->partial = NULL;
 				goto out;

--- a/src/scheduler/binding.c
+++ b/src/scheduler/binding.c
@@ -265,6 +265,7 @@ void rebind_LPs(void)
 			new_LPS_binding = rsalloc(sizeof(int) * n_prc);
 
 			lp_cost = rsalloc(sizeof(struct lp_cost_id) * n_prc);
+			memset(lp_cost, 0, sizeof(struct lp_cost_id) * n_prc);
 
 			atomic_set(&worker_thread_reduction, n_cores);
 		}


### PR DESCRIPTION
A better management of posix_memalign errors, which are now displayed as
a human-readable string.
This was done while spotting a stupid race on an uninitialized variable
under a significantly-thrashing condition of the runtime. That's fixed
now as well.

Signed-off-by: Alessandro Pellegrini <pellegrini@dis.uniroma1.it>