### PR TITLE
Validate messages once in debug mode

### DIFF
--- a/src/communication/communication.c
+++ b/src/communication/communication.c
@@ -366,8 +366,6 @@ void send_antimessages(struct lp_struct *lp, simtime_t after_simtime)
  */
 void Send(msg_t *msg)
 {
-	validate_msg(msg);
-
 #ifdef HAVE_MPI
 	// Check whether the message recepient kernel is remote
 	if (find_kernel_by_gid(msg->receiver) != kid) {

--- a/src/communication/mpi.c
+++ b/src/communication/mpi.c
@@ -173,6 +173,8 @@ void send_remote_msg(msg_t *msg)
 	out_msg->msg->colour = threads_phase_colour[local_tid];
 	unsigned int dest = find_kernel_by_gid(msg->receiver);
 
+	validate_msg(msg);
+
 	register_outgoing_msg(out_msg->msg);
 
 	lock_mpi();


### PR DESCRIPTION
Moving `validate_msg()` from `Send()` to `send_remote_msg()` avoids to
validate twice the same message in case it is locally delivered.

This affects only runs built with debugging support, so it's not a
performance-critical commit. This fixes #73.

Signed-off-by: Alessandro Pellegrini <pellegrini@dis.uniroma1.it>