### PR TITLE
Fix per-thread jump buffer

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -66,7 +66,7 @@ enum {
 	VERBOSE_NO		/**< xxx documentation */
 };
 
-extern jmp_buf exit_jmp;
+extern __thread jmp_buf exit_jmp;
 
 /// Optimize the branch as likely taken
 #define likely(exp) __builtin_expect(exp, 1)

--- a/src/main.c
+++ b/src/main.c
@@ -59,8 +59,7 @@
  * all threads synchronize. This avoids side effects like, e.g., accessing
  * a NULL pointer.
  */
-
-jmp_buf exit_jmp;
+__thread jmp_buf exit_jmp;
 
 /**
 * This function checks the different possibilities for termination detection termination.


### PR DESCRIPTION
The leave buffer used for simulation exit was inadverently not allocated
in TLS, causing (with a very small probability) a nasty segfault when a
thread was leaving the simulation at the very end.

Signed-off-by: Alessandro Pellegrini <pellegrini@dis.uniroma1.it>