### PR TITLE
Set current before giving control to OnGVT

### DIFF
--- a/src/gvt/ccgs.c
+++ b/src/gvt/ccgs.c
@@ -152,10 +152,15 @@ void ccgs_compute_snapshot(state_t *time_barrier_pointer[])
  */
 bool ccgs_lp_can_halt(struct lp_struct *lp)
 {
+	bool ret;
 	if (rootsim_config.check_termination_mode == CKTRM_INCREMENTAL && lps_termination[lp->lid.to_int]) {
 		return true;
 	}
-	return lp->OnGVT(lp->gid.to_int, lp->current_base_pointer);
+	current = lp;
+	ret = lp->OnGVT(lp->gid.to_int, lp->current_base_pointer);
+	current = NULL;
+	
+	return ret;
 }
 
 void ccgs_init(void)


### PR DESCRIPTION
OnGVT is allowed to call a subset of platform-level API functions. Some
of these rely on `current` to work, which was not set before calling
OnGVT, thus causing the runtime to crash.

Signed-off-by: Alessandro Pellegrini <pellegrini@dis.uniroma1.it>